### PR TITLE
KAN-12: feat: Clean up discard events

### DIFF
--- a/apps/api/src/auth/decorators.py
+++ b/apps/api/src/auth/decorators.py
@@ -1,13 +1,14 @@
 from flask_httpauth import HTTPBasicAuth
 
 from src.auth.services import AuthenticationService
-from src.container import container
 
 auth = HTTPBasicAuth()
 
 
 @auth.verify_password
 def verify_password(username, password) -> None:
+    from src.container import container
+
     authentication_service = container.get(AuthenticationService)
     if authentication_service.authenticate(username.strip(), password.strip()):
         return username

--- a/apps/api/src/auth/decorators.py
+++ b/apps/api/src/auth/decorators.py
@@ -1,14 +1,13 @@
 from flask_httpauth import HTTPBasicAuth
 
 from src.auth.services import AuthenticationService
+from src.container import container
 
 auth = HTTPBasicAuth()
 
 
 @auth.verify_password
 def verify_password(username, password) -> None:
-    from src.container import container
-
     authentication_service = container.get(AuthenticationService)
     if authentication_service.authenticate(username.strip(), password.strip()):
         return username

--- a/apps/api/src/tracker/__init__.py
+++ b/apps/api/src/tracker/__init__.py
@@ -1,0 +1,1 @@
+from src.tracker.workers import cleanup_discard_worker  # noqa: F401

--- a/apps/api/src/tracker/workers.py
+++ b/apps/api/src/tracker/workers.py
@@ -1,0 +1,45 @@
+import logging
+import time
+
+from src.core.supervisor import WorkerContext, register_worker
+from src.tracker.entities import TrackDiscard
+
+logger = logging.getLogger(__name__)
+
+LAST_EXECUTED_AT_STATE_KEY = 'last_executed_at'
+DISCARD_RETENTION_SECONDS = 30 * 60 * 60
+DISCARD_CLEANUP_PERIOD_SECONDS = 5 * 60
+
+
+@register_worker
+def cleanup_discard_worker(context: WorkerContext) -> None:
+    state = context.get_state(cleanup_discard_worker)
+
+    started_at = time.monotonic()
+    last_executed_at = state.get(LAST_EXECUTED_AT_STATE_KEY)
+    if last_executed_at and started_at - last_executed_at < DISCARD_CLEANUP_PERIOD_SECONDS:
+        return
+
+    cutoff = int(time.time()) - DISCARD_RETENTION_SECONDS
+    logger.info(
+        'Cleaning up track_discard table',
+        extra={
+            'cutoff': cutoff,
+            'retention_seconds': DISCARD_RETENTION_SECONDS,
+        },
+    )
+
+    deleted_rows = TrackDiscard.delete().where(TrackDiscard.created_at < cutoff).execute()
+    duration_ms = int((time.monotonic() - started_at) * 1000)
+
+    logger.info(
+        'track_discard cleanup is completed',
+        extra={
+            'cutoff': cutoff,
+            'retention_seconds': DISCARD_RETENTION_SECONDS,
+            'deleted_rows': deleted_rows,
+            'duration_ms': duration_ms,
+        },
+    )
+
+    state[LAST_EXECUTED_AT_STATE_KEY] = started_at

--- a/apps/api/tests/integration/track/test_discard.py
+++ b/apps/api/tests/integration/track/test_discard.py
@@ -1,30 +1,19 @@
 from time import sleep
 
 import pytest
-
-from src.container import container
-from src.core.supervisor import WorkerContext
-from src.tracker import workers
-from tests.fixtures.utils import click_uuid
+from fixtures.utils import click_uuid
 
 
 class TestCleanupDiscardWorker:
     @pytest.fixture(autouse=True)
     def mock_cleanup_discard_worker_settings(self, monkeypatch):
-        monkeypatch.setattr(workers, 'DISCARD_RETENTION_SECONDS', 300)
-        monkeypatch.setattr(workers, 'DISCARD_CLEANUP_PERIOD_SECONDS', 0.1)
-
-    @pytest.fixture(autouse=True)
-    def reset_cleanup_discard_worker_state(self):
-        state = container.get(WorkerContext).get_state(workers.cleanup_discard_worker)
-        state.clear()
-        yield
-        state.clear()
+        monkeypatch.setattr('src.tracker.workers.DISCARD_RETENTION_SECONDS', 300)
+        monkeypatch.setattr('src.tracker.workers.DISCARD_CLEANUP_PERIOD_SECONDS', 0.1)
 
     def test_cleanup_discard_worker__deletes_expired_discards(
         self, client, campaign, write_to_db, read_from_db, monkeypatch
     ):
-        monkeypatch.setattr(workers.time, 'time', lambda: 2000)
+        monkeypatch.setattr('src.tracker.workers.time.time', lambda: 2000)
 
         write_to_db(
             'track_discard',

--- a/apps/api/tests/integration/track/test_discard.py
+++ b/apps/api/tests/integration/track/test_discard.py
@@ -1,0 +1,61 @@
+from time import sleep
+
+import pytest
+
+from src.container import container
+from src.core.supervisor import WorkerContext
+from src.tracker import workers
+from tests.fixtures.utils import click_uuid
+
+
+class TestCleanupDiscardWorker:
+    @pytest.fixture(autouse=True)
+    def mock_cleanup_discard_worker_settings(self, monkeypatch):
+        monkeypatch.setattr(workers, 'DISCARD_RETENTION_SECONDS', 300)
+        monkeypatch.setattr(workers, 'DISCARD_CLEANUP_PERIOD_SECONDS', 0.1)
+
+    @pytest.fixture(autouse=True)
+    def reset_cleanup_discard_worker_state(self):
+        state = container.get(WorkerContext).get_state(workers.cleanup_discard_worker)
+        state.clear()
+        yield
+        state.clear()
+
+    def test_cleanup_discard_worker__deletes_expired_discards(
+        self, client, campaign, write_to_db, read_from_db, monkeypatch
+    ):
+        monkeypatch.setattr(workers.time, 'time', lambda: 2000)
+
+        write_to_db(
+            'track_discard',
+            {
+                'click_id': click_uuid(1),
+                'campaign_id': campaign['id'],
+                'country': 'MD',
+                'browser_family': 'Mobile Safari',
+                'os_family': 'iOS',
+                'device_family': 'iPhone',
+                'is_mobile': True,
+                'is_bot': False,
+                'created_at': 1000,
+            },
+        )
+        fresh_discard = write_to_db(
+            'track_discard',
+            {
+                'click_id': click_uuid(2),
+                'campaign_id': campaign['id'],
+                'country': 'UA',
+                'browser_family': 'Chrome',
+                'os_family': 'Android',
+                'device_family': 'Pixel 8',
+                'is_mobile': True,
+                'is_bot': False,
+                'created_at': 1900,
+            },
+        )
+
+        sleep(0.3)
+
+        discards = read_from_db('track_discard', fetchall=True)
+        assert discards == [fresh_discard]


### PR DESCRIPTION
## Summary
- Add periodic cleanup for expired `track_discard` rows.
- Register tracker cleanup during tracker module initialization.
- Add integration-style coverage for discard cleanup behavior.

## Scope
- Included:
  - Add `cleanup_discard_worker` to remove expired `track_discard` rows on a periodic cadence.
  - Log cleanup start/end with cutoff, retention, deleted row count, and duration.
  - Initialize tracker worker registration via `src.tracker.__init__`.
  - Add discard cleanup integration coverage.
- Not included:
  - Alert computation.
  - Investigation/report UI changes.
  - Configurable cleanup settings; retention and cleanup period stay hardcoded in code.

## Risks
- Low. The main behavior change is automatic deletion of old `track_discard` rows. Cleanup cadence and retention are hardcoded, so any future tuning will require a code change.

## Links
- Jira: KAN-12
- Spec: Functional https://bangitech.atlassian.net/wiki/spaces/SD/pages/589825 ; Technical https://bangitech.atlassian.net/wiki/spaces/SD/pages/622593
