### PR TITLE
KAN-13: feat: surface discard alerts in dashboard bell

### DIFF
--- a/apps/api/src/alerts/enums.py
+++ b/apps/api/src/alerts/enums.py
@@ -3,6 +3,7 @@ from enum import StrEnum
 
 class AlertCode(StrEnum):
     UNKNOWN = 'unknown'
+    CORE_CAMPAIGN_DISCARD = 'core_campaign_discard'
     FACEBOOK_PACS_BUSINESS_PORTFOLIO_ACCESS_URL_MISSING = 'facebook_pacs_business_portfolio_access_url_missing'
     FACEBOOK_PACS_BUSINESS_PORTFOLIO_ACCESS_URL_EXPIRED = 'facebook_pacs_business_portfolio_access_url_expired'
     FACEBOOK_PACS_BUSINESS_PORTFOLIO_ACCESS_URL_EXPIRING_SOON = (

--- a/apps/api/src/reports/repositories.py
+++ b/apps/api/src/reports/repositories.py
@@ -5,10 +5,11 @@ from peewee import JOIN, Case, MySQLDatabase, fn
 from pymysql.converters import escape_string
 from wireup import Inject, injectable
 
+from src.core.entities import Campaign
 from src.core.enums import LeadStatus
 from src.core.utils import log_execution_time
 from src.reports.entities import Expense, ReportLead
-from src.tracker.entities import TrackClick, TrackLead, TrackPostback
+from src.tracker.entities import TrackClick, TrackDiscard, TrackLead, TrackPostback
 
 
 @injectable
@@ -178,3 +179,31 @@ class StatisticsReportRepository:
         )
 
         return click, list(leads_query), list(postbacks_query)
+
+    def campaign_window_totals(self, *, start_5m: int, start_1h: int, start_1d: int):
+        query = (
+            TrackClick.select(
+                TrackClick.campaign_id.alias('campaign_id'),
+                Campaign.name.alias('campaign_name'),
+                fn.SUM(TrackClick.created_at >= start_5m).alias('total_5m'),
+                fn.SUM(TrackClick.created_at >= start_1h).alias('total_1h'),
+                fn.SUM(TrackClick.created_at >= start_1d).alias('total_1d'),
+            )
+            .join(Campaign, JOIN.INNER, on=(TrackClick.campaign_id == Campaign.id))
+            .where(TrackClick.created_at >= start_1d)
+            .group_by(TrackClick.campaign_id, Campaign.name)
+        )
+        return list(query.dicts())
+
+    def campaign_window_discard_totals(self, *, start_5m: int, start_1h: int, start_1d: int):
+        query = (
+            TrackDiscard.select(
+                TrackDiscard.campaign_id.alias('campaign_id'),
+                fn.SUM(TrackDiscard.created_at >= start_5m).alias('discard_5m'),
+                fn.SUM(TrackDiscard.created_at >= start_1h).alias('discard_1h'),
+                fn.SUM(TrackDiscard.created_at >= start_1d).alias('discard_1d'),
+            )
+            .where(TrackDiscard.created_at >= start_1d)
+            .group_by(TrackDiscard.campaign_id)
+        )
+        return list(query.dicts())

--- a/apps/api/src/reports/services.py
+++ b/apps/api/src/reports/services.py
@@ -4,6 +4,7 @@ from decimal import ROUND_FLOOR, Decimal
 
 from wireup import injectable
 
+from src.alerts import Alert, AlertCode, AlertSeverity, register_alert_callback
 from src.core.entities import Campaign
 from src.core.enums import LeadStatus, SortOrder
 from src.core.services import CampaignService
@@ -13,6 +14,13 @@ from src.reports.exceptions import ClickDoesNotExistError, ExpensesDistributionP
 from src.reports.repositories import StatisticsReportRepository
 from src.tracker.entities import TrackClick
 from src.tracker.services import TrackService
+
+DISCARD_WINDOW_SECONDS = {
+    '5m': 5 * 60,
+    '1h': 60 * 60,
+    '1d': 24 * 60 * 60,
+}
+DISCARD_MIN_TOTAL = 20
 
 
 @injectable
@@ -343,6 +351,34 @@ class ReportService:
 
 @injectable
 class ReportHelperService:
+    @staticmethod
+    def build_discard_metric(discard_count: int, total_count: int) -> dict:
+        rate = round(discard_count / total_count, 4) if total_count else 0.0
+        return {
+            'discardCount': discard_count,
+            'totalCount': total_count,
+            'rate': rate,
+            'eligible': total_count >= DISCARD_MIN_TOTAL,
+        }
+
+    @staticmethod
+    def get_discard_severity(metric: dict) -> AlertSeverity | None:
+        if not metric['eligible'] or metric['rate'] <= 0:
+            return None
+        if metric['rate'] < 0.02:
+            return AlertSeverity.INFO
+        if metric['rate'] < 0.20:
+            return AlertSeverity.WARNING
+        return AlertSeverity.ERROR
+
+    @staticmethod
+    def format_discard_message(campaign_name: str, metrics: dict[str, dict]) -> str:
+        metrics_text = ', '.join(
+            f'{window}: {metric["discardCount"]}/{metric["totalCount"]} ({metric["rate"] * 100:.1f}%)'
+            for window, metric in metrics.items()
+        )
+        return f'Campaign "{campaign_name}" has discards. {metrics_text}. Review flow routing.'
+
     def list_expenses_distribution_parameters(self, campaign_id):
         parameters = set()
         query = TrackClick.select(TrackClick.parameters).where(TrackClick.campaign_id == campaign_id)
@@ -362,3 +398,66 @@ class ReportHelperService:
             values.add(value)
 
         return sorted(values)
+
+
+@register_alert_callback
+def collect_discard_alerts(container):
+    statistics_report_repository = container.get(StatisticsReportRepository)
+
+    now_timestamp = int(utcnow().timestamp())
+    window_starts = {window: now_timestamp - seconds for window, seconds in DISCARD_WINDOW_SECONDS.items()}
+
+    totals_by_campaign = {
+        row['campaign_id']: row
+        for row in statistics_report_repository.campaign_window_totals(
+            start_5m=window_starts['5m'],
+            start_1h=window_starts['1h'],
+            start_1d=window_starts['1d'],
+        )
+    }
+    discard_by_campaign = {
+        row['campaign_id']: row
+        for row in statistics_report_repository.campaign_window_discard_totals(
+            start_5m=window_starts['5m'],
+            start_1h=window_starts['1h'],
+            start_1d=window_starts['1d'],
+        )
+    }
+
+    alerts = []
+    for campaign_id, total_row in totals_by_campaign.items():
+        discard_row = discard_by_campaign.get(campaign_id, {})
+        metrics = {
+            '5m': ReportHelperService.build_discard_metric(
+                int(discard_row.get('discard_5m') or 0),
+                int(total_row.get('total_5m') or 0),
+            ),
+            '1h': ReportHelperService.build_discard_metric(
+                int(discard_row.get('discard_1h') or 0),
+                int(total_row.get('total_1h') or 0),
+            ),
+            '1d': ReportHelperService.build_discard_metric(
+                int(discard_row.get('discard_1d') or 0),
+                int(total_row.get('total_1d') or 0),
+            ),
+        }
+
+        severity = ReportHelperService.get_discard_severity(metrics['1h'])
+        if severity is None:
+            continue
+
+        alerts.append(
+            Alert(
+                code=AlertCode.CORE_CAMPAIGN_DISCARD,
+                message=ReportHelperService.format_discard_message(total_row['campaign_name'], metrics),
+                severity=severity,
+                payload={
+                    'campaignId': campaign_id,
+                    'campaignName': total_row['campaign_name'],
+                    'severityWindow': '1h',
+                    'metrics': metrics,
+                },
+            )
+        )
+
+    return alerts

--- a/apps/api/tests/integration/track/test_alerts.py
+++ b/apps/api/tests/integration/track/test_alerts.py
@@ -1,0 +1,239 @@
+from fixtures.utils import click_uuid
+
+
+def test_get_alerts__suppresses_discard_alert_when_1h_total_is_too_low(
+    client, authorization, campaign, write_to_db, timestamp
+):
+    for index in range(19):
+        click = write_to_db(
+            'track_click',
+            {
+                'click_id': click_uuid(index + 1),
+                'campaign_id': campaign['id'],
+                'parameters': {},
+                'created_at': timestamp - 60,
+            },
+        )
+        write_to_db(
+            'track_discard',
+            {
+                'click_id': click['click_id'],
+                'campaign_id': campaign['id'],
+                'country': 'MD',
+                'browser_family': 'Mobile Safari',
+                'os_family': 'iOS',
+                'device_family': 'iPhone',
+                'is_mobile': True,
+                'is_bot': False,
+                'created_at': timestamp - 60,
+            },
+            returning=False,
+        )
+
+    response = client.get('/api/v2/alerts', headers={'Authorization': authorization})
+
+    assert response.status_code == 200, response.text
+    assert response.json == {'content': []}
+
+
+def test_get_alerts__returns_info_discard_alert(client, authorization, campaign, write_to_db, timestamp):
+    for index in range(100):
+        click = write_to_db(
+            'track_click',
+            {
+                'click_id': click_uuid(index + 1),
+                'campaign_id': campaign['id'],
+                'parameters': {},
+                'created_at': timestamp - 60,
+            },
+        )
+        if index == 0:
+            write_to_db(
+                'track_discard',
+                {
+                    'click_id': click['click_id'],
+                    'campaign_id': campaign['id'],
+                    'country': 'MD',
+                    'browser_family': 'Mobile Safari',
+                    'os_family': 'iOS',
+                    'device_family': 'iPhone',
+                    'is_mobile': True,
+                    'is_bot': False,
+                    'created_at': timestamp - 60,
+                },
+                returning=False,
+            )
+
+    response = client.get('/api/v2/alerts', headers={'Authorization': authorization})
+
+    assert response.status_code == 200, response.text
+    assert response.json == {
+        'content': [
+            {
+                'code': 'core_campaign_discard',
+                'message': (
+                    f'Campaign "{campaign["name"]}" has discards. '
+                    '5m: 1/100 (1.0%), 1h: 1/100 (1.0%), 1d: 1/100 (1.0%). Review flow routing.'
+                ),
+                'severity': 'info',
+                'source': 'src.reports.services',
+                'payload': {
+                    'campaignId': campaign['id'],
+                    'campaignName': campaign['name'],
+                    'severityWindow': '1h',
+                    'metrics': {
+                        '5m': {'discardCount': 1, 'totalCount': 100, 'rate': 0.01, 'eligible': True},
+                        '1h': {'discardCount': 1, 'totalCount': 100, 'rate': 0.01, 'eligible': True},
+                        '1d': {'discardCount': 1, 'totalCount': 100, 'rate': 0.01, 'eligible': True},
+                    },
+                },
+            }
+        ]
+    }
+
+
+def test_get_alerts__returns_warning_discard_alert(client, authorization, campaign, write_to_db, timestamp):
+    # Inside all windows: contributes to 5m, 1h, and 1d.
+    for index in range(25):
+        click = write_to_db(
+            'track_click',
+            {
+                'click_id': click_uuid(index + 1),
+                'campaign_id': campaign['id'],
+                'parameters': {},
+                'created_at': timestamp - 120,
+            },
+        )
+        if index == 0:
+            write_to_db(
+                'track_discard',
+                {
+                    'click_id': click['click_id'],
+                    'campaign_id': campaign['id'],
+                    'country': 'MD',
+                    'browser_family': 'Mobile Safari',
+                    'os_family': 'iOS',
+                    'device_family': 'iPhone',
+                    'is_mobile': True,
+                    'is_bot': False,
+                    'created_at': timestamp - 120,
+                },
+                returning=False,
+            )
+
+    # Older than 5m but inside 1h and 1d: contributes only to 1h and 1d.
+    for index in range(20):
+        click = write_to_db(
+            'track_click',
+            {
+                'click_id': click_uuid(index + 101),
+                'campaign_id': campaign['id'],
+                'parameters': {},
+                'created_at': timestamp - 1200,
+            },
+        )
+        if index < 2:
+            write_to_db(
+                'track_discard',
+                {
+                    'click_id': click['click_id'],
+                    'campaign_id': campaign['id'],
+                    'country': 'MD',
+                    'browser_family': 'Mobile Safari',
+                    'os_family': 'iOS',
+                    'device_family': 'iPhone',
+                    'is_mobile': True,
+                    'is_bot': False,
+                    'created_at': timestamp - 1200,
+                },
+                returning=False,
+            )
+
+    # Older than 1h but inside 1d: contributes only to 1d.
+    for index in range(10):
+        click = write_to_db(
+            'track_click',
+            {
+                'click_id': click_uuid(index + 201),
+                'campaign_id': campaign['id'],
+                'parameters': {},
+                'created_at': timestamp - 7200,
+            },
+        )
+        if index < 9:
+            write_to_db(
+                'track_discard',
+                {
+                    'click_id': click['click_id'],
+                    'campaign_id': campaign['id'],
+                    'country': 'MD',
+                    'browser_family': 'Mobile Safari',
+                    'os_family': 'iOS',
+                    'device_family': 'iPhone',
+                    'is_mobile': True,
+                    'is_bot': False,
+                    'created_at': timestamp - 7200,
+                },
+                returning=False,
+            )
+
+    response = client.get('/api/v2/alerts', headers={'Authorization': authorization})
+
+    assert response.status_code == 200, response.text
+    assert response.json == {
+        'content': [
+            {
+                'code': 'core_campaign_discard',
+                'message': (
+                    f'Campaign "{campaign["name"]}" has discards. '
+                    '5m: 1/25 (4.0%), 1h: 3/45 (6.7%), 1d: 12/55 (21.8%). Review flow routing.'
+                ),
+                'severity': 'warning',
+                'source': 'src.reports.services',
+                'payload': {
+                    'campaignId': campaign['id'],
+                    'campaignName': campaign['name'],
+                    'severityWindow': '1h',
+                    'metrics': {
+                        '5m': {'discardCount': 1, 'totalCount': 25, 'rate': 0.04, 'eligible': True},
+                        '1h': {'discardCount': 3, 'totalCount': 45, 'rate': 0.0667, 'eligible': True},
+                        '1d': {'discardCount': 12, 'totalCount': 55, 'rate': 0.2182, 'eligible': True},
+                    },
+                },
+            }
+        ]
+    }
+
+
+def test_get_alerts__returns_error_discard_alert(client, authorization, campaign, write_to_db, timestamp):
+    for index in range(25):
+        click = write_to_db(
+            'track_click',
+            {
+                'click_id': click_uuid(index + 1),
+                'campaign_id': campaign['id'],
+                'parameters': {},
+                'created_at': timestamp - 60,
+            },
+        )
+        if index < 5:
+            write_to_db(
+                'track_discard',
+                {
+                    'click_id': click['click_id'],
+                    'campaign_id': campaign['id'],
+                    'country': 'MD',
+                    'browser_family': 'Mobile Safari',
+                    'os_family': 'iOS',
+                    'device_family': 'iPhone',
+                    'is_mobile': True,
+                    'is_bot': False,
+                    'created_at': timestamp - 60,
+                },
+                returning=False,
+            )
+
+    response = client.get('/api/v2/alerts', headers={'Authorization': authorization})
+
+    assert response.status_code == 200, response.text
+    assert response.json['content'][0]['severity'] == 'error'

--- a/apps/web/src/components/alerts_bell.js
+++ b/apps/web/src/components/alerts_bell.js
@@ -7,8 +7,12 @@ function severityClass(alerts) {
 
   var severity = alerts.highestSeverity();
 
+  if (severity === "error") {
+    return "alerts-bell-icon alerts-bell-icon-error";
+  }
+
   if (severity === "warning") {
-    return "text-danger";
+    return "alerts-bell-icon alerts-bell-icon-warning";
   }
 
   if (severity === "info") {
@@ -19,6 +23,10 @@ function severityClass(alerts) {
 }
 
 function alertIconClass(code) {
+  if (code === "core_campaign_discard") {
+    return "fa fa-exclamation-triangle";
+  }
+
   if (
       code === "facebook_pacs_business_portfolio_access_url_missing"
       || code === "facebook_pacs_business_portfolio_access_url_expiring_soon"
@@ -31,8 +39,12 @@ function alertIconClass(code) {
 }
 
 function itemSeverityClass(severity) {
-  if (severity === "warning" || severity === "error") {
-    return "text-danger";
+  if (severity === "error") {
+    return "alerts-bell-icon-error";
+  }
+
+  if (severity === "warning") {
+    return "alerts-bell-icon-warning";
   }
 
   if (severity === "info") {

--- a/apps/web/src/models/alerts.js
+++ b/apps/web/src/models/alerts.js
@@ -1,7 +1,7 @@
 const m = require("mithril");
 var config = require("../config");
 
-var POLL_INTERVAL_MS = 10 * 60 * 1000;
+var POLL_INTERVAL_MS = 1 * 60 * 1000;
 
 class AlertsModel {
   constructor(auth) {
@@ -63,10 +63,11 @@ class AlertsModel {
       return item.severity;
     });
 
-    if (
-      severities.indexOf("warning") !== -1 ||
-      severities.indexOf("error") !== -1
-    ) {
+    if (severities.indexOf("error") !== -1) {
+      return "error";
+    }
+
+    if (severities.indexOf("warning") !== -1) {
       return "warning";
     }
 

--- a/apps/web/styles/app.css
+++ b/apps/web/styles/app.css
@@ -37,6 +37,14 @@
   color: #fd7e14;
 }
 
+.alerts-bell-icon-warning {
+  color: #fd7e14;
+}
+
+.alerts-bell-icon-error {
+  color: #dc3545;
+}
+
 .alerts-dropdown {
   min-width: 320px;
   max-width: 420px;


### PR DESCRIPTION
## Summary
- Surface discard-based campaign alerts in `/api/v2/alerts` using `track_click` as total traffic and `track_discard` as discard traffic.
- Add backend severity evaluation and 5m / 1h / 1d metrics for discard alerts, plus tracker integration coverage for the new alert payload.
- Update the dashboard alerts bell to poll every minute, show a discard-specific icon, and visually differentiate `warning` from `error`.

## Scope
- Included:
  - Backend discard alert code and aggregation queries in `apps/api`
  - Integration tests for discard alerts in `apps/api/tests/integration/track/test_alerts.py`
  - Alerts bell polling and severity/icon styling updates in `apps/web`
- Not included:
  - New discard investigation pages or reports beyond the existing alerts bell
  - Changes to discard capture semantics already introduced in KAN-12

## Risks
- Low to moderate risk: alert aggregation now depends on grouped `/api/v2/alerts` queries over the last 24h of `track_click` and `track_discard`, so the main risk is query cost under higher traffic.
- UI severity styling changed for the alerts bell, so warning/error color treatment should be spot-checked in the dashboard.

## Links
- Jira: https://bangitech.atlassian.net/browse/KAN-13
- Spec: Functional: https://bangitech.atlassian.net/wiki/spaces/SD/pages/589825, Technical: https://bangitech.atlassian.net/wiki/spaces/SD/pages/622593
