### PR TITLE
KAN-16: feat: add disk telemetry ingestion command and host script

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -106,3 +106,19 @@ docker push ghcr.io/devalentino/bangi-backend:$(git describe --tags --exact-matc
 
 - Health check: `/api/v2/health`
 - OpenAPI docs: `/openapi/swagger-ui`
+
+## Storage monitoring ingestion
+
+The internal disk telemetry command lives at:
+
+```bash
+python -m src.health.ingest.disk_utilization \
+  --filesystem "/dev/sda1" \
+  --mountpoint "/var/lib/docker" \
+  --total-bytes 21474836480 \
+  --used-bytes 15032385536 \
+  --available-bytes 6442450944 \
+  --used-percent 70.0
+```
+
+The host-side wrapper script and cron setup notes live in [`scripts/README.md`](../../scripts/README.md).

--- a/apps/api/migrations/008_health_disk_utilization.py
+++ b/apps/api/migrations/008_health_disk_utilization.py
@@ -1,0 +1,38 @@
+"""Peewee migrations -- 008_health_disk_utilization.py."""
+
+from contextlib import suppress
+
+import peewee as pw
+from peewee_migrate import Migrator
+
+
+with suppress(ImportError):
+    import playhouse.postgres_ext as pw_pext
+
+
+HEALTH_DISK_UTILIZATION_TABLE = 'health_disk_utilization'
+
+
+def migrate(migrator: Migrator, database: pw.Database, *, fake=False):
+    """Write your migrations here."""
+
+    @migrator.create_model
+    class DiskUtilization(pw.Model):
+        id = pw.AutoField()
+        created_at = pw.TimestampField(null=True)
+        filesystem = pw.CharField(max_length=255)
+        mountpoint = pw.CharField(max_length=255)
+        total_bytes = pw.BigIntegerField()
+        used_bytes = pw.BigIntegerField()
+        available_bytes = pw.BigIntegerField()
+        used_percent = pw.DecimalField(max_digits=5, decimal_places=2, auto_round=True)
+
+        class Meta:
+            table_name = HEALTH_DISK_UTILIZATION_TABLE
+            table_settings = ('ENGINE=Aria', 'TRANSACTIONAL=0')
+
+
+def rollback(migrator: Migrator, database: pw.Database, *, fake=False):
+    """Write your rollback migrations here."""
+
+    migrator.remove_model(HEALTH_DISK_UTILIZATION_TABLE)

--- a/apps/api/src/container.py
+++ b/apps/api/src/container.py
@@ -16,6 +16,7 @@ from src.facebook_pacs.services import BusinessPageService as FacebookPacsBusine
 from src.facebook_pacs.services import BusinessPortfolioService as FacebookPacsBusinessPortfolioService
 from src.facebook_pacs.services import CampaignService as FacebookPacsCampaignService
 from src.facebook_pacs.services import ExecutorService as FacebookPacsExecutorService
+from src.health.services import HealthService
 from src.reports.repositories import StatisticsReportRepository
 from src.reports.services import ReportHelperService, ReportService
 from src.tracker.services import TrackService
@@ -63,6 +64,7 @@ container = create_sync_container(
         FacebookPacsBusinessPortfolioService,
         FacebookPacsCampaignService,
         FacebookPacsExecutorService,
+        HealthService,
         Ip2LocationLocator,
         ReportHelperService,
         ReportService,

--- a/apps/api/src/health/entities.py
+++ b/apps/api/src/health/entities.py
@@ -1,0 +1,16 @@
+from peewee import BigIntegerField, CharField, DecimalField
+
+from src.core.entities import Entity
+
+
+class DiskUtilization(Entity):
+    filesystem = CharField(max_length=255)
+    mountpoint = CharField(max_length=255)
+    total_bytes = BigIntegerField()
+    used_bytes = BigIntegerField()
+    available_bytes = BigIntegerField()
+    used_percent = DecimalField(max_digits=5, decimal_places=2, auto_round=True)
+
+    class Meta:
+        table_name = 'health_disk_utilization'
+        table_settings = ('ENGINE=Aria', 'TRANSACTIONAL=0')

--- a/apps/api/src/health/ingest/disk_utilization.py
+++ b/apps/api/src/health/ingest/disk_utilization.py
@@ -40,7 +40,12 @@ def main(argv=None):
         print(json.dumps({'errors': exc.messages}, sort_keys=True), file=sys.stderr)
         return 2
 
-    container.get(HealthService).ingest_disk_utilization(**payload)
+    try:
+        container.get(HealthService).ingest_disk_utilization(**payload)
+    except Exception as exc:
+        print(f'Failed to ingest disk utilization: {exc}', file=sys.stderr)
+        return 1
+
     return 0
 
 

--- a/apps/api/src/health/ingest/disk_utilization.py
+++ b/apps/api/src/health/ingest/disk_utilization.py
@@ -1,0 +1,48 @@
+import argparse
+import json
+import sys
+
+from marshmallow import ValidationError
+
+from src.health.schemas import DiskUtilizationIngestRequestSchema
+
+
+def _build_parser():
+    parser = argparse.ArgumentParser(prog='python -m src.health.ingest.disk_utilization')
+    parser.add_argument('--filesystem', required=True)
+    parser.add_argument('--mountpoint', required=True)
+    parser.add_argument('--total-bytes', required=True, type=int)
+    parser.add_argument('--used-bytes', required=True, type=int)
+    parser.add_argument('--available-bytes', required=True, type=int)
+    parser.add_argument('--used-percent', required=True)
+    return parser
+
+
+def main(argv=None):
+    from src.container import container
+    from src.health.services import HealthService
+
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        payload = DiskUtilizationIngestRequestSchema().load(
+            {
+                'filesystem': args.filesystem,
+                'mountpoint': args.mountpoint,
+                'total_bytes': args.total_bytes,
+                'used_bytes': args.used_bytes,
+                'available_bytes': args.available_bytes,
+                'used_percent': args.used_percent,
+            }
+        )
+    except ValidationError as exc:
+        print(json.dumps({'errors': exc.messages}, sort_keys=True), file=sys.stderr)
+        return 2
+
+    container.get(HealthService).ingest_disk_utilization(**payload)
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/apps/api/src/health/schemas.py
+++ b/apps/api/src/health/schemas.py
@@ -1,0 +1,49 @@
+from marshmallow import ValidationError, fields, validates, validates_schema
+
+from src.core.schemas import Schema
+
+
+class DiskUtilizationIngestRequestSchema(Schema):
+    filesystem = fields.String(required=True)
+    mountpoint = fields.String(required=True)
+    total_bytes = fields.Integer(required=True, strict=True)
+    used_bytes = fields.Integer(required=True, strict=True)
+    available_bytes = fields.Integer(required=True, strict=True)
+    used_percent = fields.Decimal(required=True, as_string=False)
+
+    @validates('filesystem')
+    def validate_filesystem(self, value, **kwargs):
+        if value.strip() == '':
+            raise ValidationError('filesystem cannot be blank.')
+
+    @validates('mountpoint')
+    def validate_mountpoint(self, value, **kwargs):
+        if value.strip() == '':
+            raise ValidationError('mountpoint cannot be blank.')
+
+    @validates_schema
+    def validate_values(self, data, **kwargs):
+        total_bytes = data.get('total_bytes')
+        used_bytes = data.get('used_bytes')
+        available_bytes = data.get('available_bytes')
+        used_percent = data.get('used_percent')
+
+        for field_name in ('total_bytes', 'used_bytes', 'available_bytes'):
+            value = data.get(field_name)
+            if value is not None and value < 0:
+                raise ValidationError(f'{field_name} must be greater than or equal to 0.', field_name=field_name)
+
+        if used_percent is not None and (used_percent < 0 or used_percent > 100):
+            raise ValidationError('used_percent must be between 0 and 100.', field_name='used_percent')
+
+        if total_bytes is None:
+            return
+
+        if used_bytes is not None and used_bytes > total_bytes:
+            raise ValidationError('used_bytes must be less than or equal to total_bytes.', field_name='used_bytes')
+
+        if available_bytes is not None and available_bytes > total_bytes:
+            raise ValidationError(
+                'available_bytes must be less than or equal to total_bytes.',
+                field_name='available_bytes',
+            )

--- a/apps/api/src/health/services.py
+++ b/apps/api/src/health/services.py
@@ -1,0 +1,28 @@
+from decimal import Decimal
+
+from wireup import injectable
+
+from src.health.entities import DiskUtilization
+
+
+@injectable
+class HealthService:
+    def ingest_disk_utilization(
+        self,
+        filesystem: str,
+        mountpoint: str,
+        total_bytes: int,
+        used_bytes: int,
+        available_bytes: int,
+        used_percent: Decimal,
+    ) -> DiskUtilization:
+        snapshot = DiskUtilization(
+            filesystem=filesystem,
+            mountpoint=mountpoint,
+            total_bytes=total_bytes,
+            used_bytes=used_bytes,
+            available_bytes=available_bytes,
+            used_percent=used_percent,
+        )
+        snapshot.save()
+        return snapshot

--- a/apps/api/tests/integration/test_health.py
+++ b/apps/api/tests/integration/test_health.py
@@ -43,7 +43,33 @@ class TestDiskUtilizationIngestionCommand:
         }
         assert row['created_at'] is not None
 
-    def test_returns_non_zero_and_does_not_persist_invalid_payload(self, capsys, read_from_db):
+    def test_returns_non_zero_and_does_not_persist_invalid_payload__used_percent_101(self, capsys, read_from_db):
+        from src.health.ingest.disk_utilization import main as ingest_disk_utilization
+
+        exit_code = ingest_disk_utilization(
+            [
+                '--filesystem',
+                '/dev/sda1',
+                '--mountpoint',
+                '/var/lib/docker',
+                '--total-bytes',
+                '100',
+                '--used-bytes',
+                '100',
+                '--available-bytes',
+                '0',
+                '--used-percent',
+                '101',
+            ]
+        )
+
+        captured = capsys.readouterr()
+
+        assert exit_code == 2
+        assert read_from_db('health_disk_utilization') is None
+        assert captured.err == '{"errors": {"used_percent": ["used_percent must be between 0 and 100."]}}\n'
+
+    def test_returns_non_zero_and_does_not_persist_payload_with_used_bytes_above_total(self, capsys, read_from_db):
         from src.health.ingest.disk_utilization import main as ingest_disk_utilization
 
         exit_code = ingest_disk_utilization(
@@ -59,7 +85,7 @@ class TestDiskUtilizationIngestionCommand:
                 '--available-bytes',
                 '0',
                 '--used-percent',
-                '101',
+                '100',
             ]
         )
 
@@ -67,4 +93,4 @@ class TestDiskUtilizationIngestionCommand:
 
         assert exit_code == 2
         assert read_from_db('health_disk_utilization') is None
-        assert captured.err == '{"errors": {"used_percent": ["used_percent must be between 0 and 100."]}}\n'
+        assert captured.err == '{"errors": {"used_bytes": ["used_bytes must be less than or equal to total_bytes."]}}\n'

--- a/apps/api/tests/integration/test_health.py
+++ b/apps/api/tests/integration/test_health.py
@@ -1,4 +1,70 @@
+from decimal import Decimal
+
+
 def test_health(client):
     response = client.get('/api/v2/health')
     assert response.status_code == 200, response.text
     assert response.json == {'healthy': True}
+
+
+class TestDiskUtilizationIngestionCommand:
+    def test_persists_snapshot_for_valid_payload(self, read_from_db):
+        from src.health.ingest.disk_utilization import main as ingest_disk_utilization
+
+        exit_code = ingest_disk_utilization(
+            [
+                '--filesystem',
+                '/dev/sda1',
+                '--mountpoint',
+                '/var/lib/docker',
+                '--total-bytes',
+                '21474836480',
+                '--used-bytes',
+                '15032385536',
+                '--available-bytes',
+                '6442450944',
+                '--used-percent',
+                '70.0',
+            ]
+        )
+
+        row = read_from_db('health_disk_utilization')
+
+        assert exit_code == 0
+        assert row == {
+            'id': 1,
+            'created_at': row['created_at'],
+            'filesystem': '/dev/sda1',
+            'mountpoint': '/var/lib/docker',
+            'total_bytes': 21474836480,
+            'used_bytes': 15032385536,
+            'available_bytes': 6442450944,
+            'used_percent': Decimal('70.00'),
+        }
+        assert row['created_at'] is not None
+
+    def test_returns_non_zero_and_does_not_persist_invalid_payload(self, capsys, read_from_db):
+        from src.health.ingest.disk_utilization import main as ingest_disk_utilization
+
+        exit_code = ingest_disk_utilization(
+            [
+                '--filesystem',
+                '/dev/sda1',
+                '--mountpoint',
+                '/var/lib/docker',
+                '--total-bytes',
+                '100',
+                '--used-bytes',
+                '101',
+                '--available-bytes',
+                '0',
+                '--used-percent',
+                '101',
+            ]
+        )
+
+        captured = capsys.readouterr()
+
+        assert exit_code == 2
+        assert read_from_db('health_disk_utilization') is None
+        assert captured.err == '{"errors": {"used_percent": ["used_percent must be between 0 and 100."]}}\n'

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,34 @@
+# Storage Monitoring Scripts
+
+## Disk utilization ingestion
+
+`ingest_disk_utilization.sh` collects host disk telemetry with `df`, normalizes it, and pushes it into the backend through the internal command:
+
+```bash
+docker compose exec -T api python -m src.health.ingest.disk_utilization ...
+```
+
+Default behavior:
+
+- `MONITOR_PATH=/var/lib/docker`
+- `COMPOSE_SERVICE=api`
+- `PYTHON_BIN=python`
+- `DOCKER_COMPOSE_BIN="docker compose"`
+
+Manual run from the repo root:
+
+```bash
+./scripts/ingest_disk_utilization.sh
+```
+
+Example cron entry for hourly collection:
+
+```cron
+0 * * * * cd /path/to/bangi && ./scripts/ingest_disk_utilization.sh >> /var/log/bangi-disk-utilization.log 2>&1
+```
+
+Operational notes:
+
+- run the script on the Docker host, not inside the container
+- a non-zero exit code means ingestion failed and cron should treat it as an error
+- override `MONITOR_PATH` if Bangi data lives on a different host mount

--- a/scripts/ingest_disk_utilization.sh
+++ b/scripts/ingest_disk_utilization.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+MONITOR_PATH="${MONITOR_PATH:-/var/lib/docker}"
+COMPOSE_SERVICE="${COMPOSE_SERVICE:-api}"
+PYTHON_BIN="${PYTHON_BIN:-python}"
+DOCKER_COMPOSE_BIN="${DOCKER_COMPOSE_BIN:-docker compose}"
+
+if [[ ! -d "${MONITOR_PATH}" && ! -e "${MONITOR_PATH}" ]]; then
+  echo "MONITOR_PATH does not exist: ${MONITOR_PATH}" >&2
+  exit 1
+fi
+
+mapfile -t DF_VALUES < <(df -B1 -P "${MONITOR_PATH}" | awk 'NR==2 {print $1; print $2; print $3; print $4; print $6}')
+
+if [[ "${#DF_VALUES[@]}" -ne 5 ]]; then
+  echo "Failed to read disk metrics for ${MONITOR_PATH}" >&2
+  exit 1
+fi
+
+FILESYSTEM="${DF_VALUES[0]}"
+TOTAL_BYTES="${DF_VALUES[1]}"
+USED_BYTES="${DF_VALUES[2]}"
+AVAILABLE_BYTES="${DF_VALUES[3]}"
+MOUNTPOINT="${DF_VALUES[4]}"
+USED_PERCENT="$(awk -v used="${USED_BYTES}" -v total="${TOTAL_BYTES}" 'BEGIN { if (total == 0) { print "0.00"; exit } printf "%.2f", (used / total) * 100 }')"
+
+cd "${REPO_ROOT}"
+${DOCKER_COMPOSE_BIN} exec -T "${COMPOSE_SERVICE}" "${PYTHON_BIN}" -m src.health.ingest.disk_utilization \
+  --filesystem "${FILESYSTEM}" \
+  --mountpoint "${MOUNTPOINT}" \
+  --total-bytes "${TOTAL_BYTES}" \
+  --used-bytes "${USED_BYTES}" \
+  --available-bytes "${AVAILABLE_BYTES}" \
+  --used-percent "${USED_PERCENT}"


### PR DESCRIPTION
## Summary
- add the internal disk telemetry ingestion command under `src.health.ingest.disk_utilization`
- validate filesystem, mountpoint, byte counters, and used-percent before persisting snapshots
- persist disk utilization snapshots through `HealthService` into the `health_disk_utilization` Aria table
- add the repo-managed host script and cron/setup documentation for `docker compose exec` ingestion

## Scope
- Included:
  - migration for `health_disk_utilization`
  - `DiskUtilization` entity, validation schema, service wiring, and CLI entrypoint
  - integration coverage for valid and invalid command payloads
  - host-side ingestion script and operational docs
- Not included:
  - disk history read API and System Health UI
  - alerting, retention worker, or campaign attribution work
  - local test execution; verification remains in automation

## Risks
- Low risk. Scope is isolated to the new storage-ingestion path, but it introduces a new internal command and host script that depend on correct host `docker compose` and mount-path configuration.

## Links
- Jira: https://bangitech.atlassian.net/browse/KAN-16
- Spec: https://bangitech.atlassian.net/wiki/spaces/SD/pages/1703937/Storage+Monitoring+Technical+Specification
