### PR TITLE
KAN-19: feat: add health dashboard for disk utilization monitoring

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,3 +13,4 @@ apps/web/.cache
 node_modules
 bin
 npm-debug.log
+_dashmin-1.0.0

--- a/.gitignore
+++ b/.gitignore
@@ -221,3 +221,4 @@ landings
 perf/out
 IP2LOCATION*BIN
 *.iml
+_dashmin-1.0.0

--- a/apps/api/src/health/routes.py
+++ b/apps/api/src/health/routes.py
@@ -44,10 +44,10 @@ class DiskUtilizationHistory(MethodView):
             },
             'content': [
                 {
-                    'createdAt': int(snapshot.created_at.timestamp()),
-                    'usedPercent': float(snapshot.used_percent),
-                    'usedBytes': snapshot.used_bytes,
-                    'availableBytes': snapshot.available_bytes,
+                    'date': snapshot['date'],
+                    'usedPercent': float(snapshot['used_bytes'] / snapshot['total_bytes'] * 100),
+                    'usedBytes': snapshot['used_bytes'],
+                    'availableBytes': snapshot['available_bytes'],
                 }
                 for snapshot in snapshots
             ],

--- a/apps/api/src/health/schemas.py
+++ b/apps/api/src/health/schemas.py
@@ -54,7 +54,7 @@ class DiskUtilizationHistoryRequestSchema(Schema):
 
 
 class DiskUtilizationHistoryPointResponseSchema(Schema):
-    createdAt = fields.Integer(required=True)
+    date = fields.Date(required=True)
     usedPercent = fields.Float(required=True)
     usedBytes = fields.Integer(required=True)
     availableBytes = fields.Integer(required=True)

--- a/apps/api/src/health/services.py
+++ b/apps/api/src/health/services.py
@@ -2,6 +2,7 @@ from decimal import Decimal
 from time import time as time_timestamp
 from typing import Annotated
 
+from peewee import fn
 from wireup import Inject, injectable
 
 from src.health.entities import DiskUtilization, DiskUtilizationSummary
@@ -43,12 +44,20 @@ class HealthService:
         now_timestamp = int(time_timestamp())
         history_start_timestamp = now_timestamp - days * 24 * 60 * 60
 
+        date = fn.date(fn.from_unixtime(DiskUtilization.created_at)).alias('date')
         rows = list(
-            DiskUtilization.select()
+            DiskUtilization.select(
+                date,
+                fn.max(DiskUtilization.total_bytes),
+                fn.avg(DiskUtilization.used_bytes),
+                fn.avg(DiskUtilization.available_bytes),
+            )
             .where(DiskUtilization.created_at >= history_start_timestamp)
+            .group_by(date)
             .order_by(DiskUtilization.created_at.asc())
+            .dicts()
         )
-        latest_snapshot = rows[-1] if rows else None
+        latest_snapshot = DiskUtilization.select().order_by(DiskUtilization.id.desc()).first()
 
         if latest_snapshot is None:
             return (

--- a/apps/api/tests/integration/test_health.py
+++ b/apps/api/tests/integration/test_health.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timezone
 from decimal import Decimal
 from time import sleep
+from unittest import mock
 
 import pytest
 
@@ -181,13 +182,13 @@ class TestDiskUtilizationHistory:
             },
             'content': [
                 {
-                    'createdAt': first_history_row['created_at'],
+                    'date': mock.ANY,
                     'usedPercent': first_history_row['used_percent'],
                     'usedBytes': first_history_row['used_bytes'],
                     'availableBytes': first_history_row['available_bytes'],
                 },
                 {
-                    'createdAt': latest_row['created_at'],
+                    'date': mock.ANY,
                     'usedPercent': latest_row['used_percent'],
                     'usedBytes': latest_row['used_bytes'],
                     'availableBytes': latest_row['available_bytes'],

--- a/apps/api/tests/integration/test_health.py
+++ b/apps/api/tests/integration/test_health.py
@@ -233,7 +233,7 @@ class TestDiskUtilizationHistory:
             },
             'content': [
                 {
-                    'createdAt': stale_timestamp,
+                    'date': mock.ANY,
                     'usedPercent': 80.0,
                     'usedBytes': 800,
                     'availableBytes': 200,

--- a/apps/web/index.js
+++ b/apps/web/index.js
@@ -5,6 +5,7 @@ var api = require("./src/models/api");
 var session = require("./src/models/session");
 var AuthenticatedPage = require("./src/components/authenticated_page");
 var authView = require("./src/views/auth");
+var healthView = require("./src/views/health");
 var statisticsView = require("./src/views/statistics");
 var expensesReportView = require("./src/views/expenses_report");
 var discardReportView = require("./src/views/discard_report");
@@ -42,6 +43,16 @@ m.route(document.getElementById("content"), "/statistics", {
     },
     render: function () {
       return m(authView.SignIn, { auth: auth });
+    },
+  },
+  "/health": {
+    onmatch: function () {
+      if (!auth.isAuthenticated) {
+        m.route.set("/sign-in");
+      }
+    },
+    render: function () {
+      return m(AuthenticatedPage, { page: healthView, auth: auth, alerts: alerts });
     },
   },
   "/statistics": {

--- a/apps/web/src/components/sidebar.js
+++ b/apps/web/src/components/sidebar.js
@@ -3,6 +3,7 @@ var m = require("mithril");
 class Sidebar {
   view() {
     let currentRoute = m.route.get();
+    let isHealthRoute = currentRoute === "/health";
     let isFacebookPacsRoute = currentRoute.indexOf("/facebook/pacs") === 0;
     let isStatisticsRoute = currentRoute === "/statistics";
     let isExpensesReportRoute = currentRoute === "/reports/expenses";
@@ -137,6 +138,14 @@ class Sidebar {
                 ],
                 ),
               ]),
+              m(
+                "a.nav-item.nav-link",
+                { href: "#!/health", class: linkClass(isHealthRoute) },
+                [
+                    m("i.fa.fa-heartbeat.me-2"),
+                    "Health",
+                ],
+              ),
             ],
           ),
         ]),

--- a/apps/web/src/models/health.js
+++ b/apps/web/src/models/health.js
@@ -1,0 +1,44 @@
+const api = require("./api");
+var config = require("../config");
+
+class HealthModel {
+  constructor() {
+    this.summary = null;
+    this.history = [];
+    this.error = null;
+    this.isLoading = false;
+  }
+
+  load() {
+    this.isLoading = true;
+
+    return api
+      .request({
+        method: "GET",
+        url: `${config.backendApiBaseUrl}/health/disk-utilization/history`,
+        params: { days: 30 },
+      })
+      .then(
+        function (payload) {
+          this.summary = payload.summary;
+          this.history = payload.content || [];
+          this.error = null;
+          this.isLoading = false;
+        }.bind(this),
+      )
+      .catch(
+        function () {
+          this.summary = null;
+          this.history = [];
+          this.error = "Failed to load disk utilization.";
+          this.isLoading = false;
+        }.bind(this),
+      );
+  }
+
+  isNeverReported() {
+    return this.summary !== null && this.summary.lastReceivedAt === null && this.history.length === 0;
+  }
+}
+
+module.exports = HealthModel;

--- a/apps/web/src/views/health.js
+++ b/apps/web/src/views/health.js
@@ -45,7 +45,7 @@ class HealthView {
       type: "line",
       data: {
         labels: this.model.history.map(function (row) {
-          return timestamp2LocalTime(row.createdAt);
+          return row.date;
         }),
         datasets: [
           {

--- a/apps/web/src/views/health.js
+++ b/apps/web/src/views/health.js
@@ -1,0 +1,137 @@
+const m = require("mithril");
+const ChartComponent = require("../components/chart");
+const HealthModel = require("../models/health");
+const { timestamp2LocalTime, timestamp2UtcTime } = require("../utils/date");
+
+function formatBytes(size) {
+  const units = ["B", "KB", "MB", "GB", "TB", "PB"];
+  let unitIndex = 0;
+
+  while (size >= 1024 && unitIndex < units.length - 1) {
+    size /= 1024;
+    unitIndex += 1;
+  }
+
+  const digits = unitIndex === 0 ? 0 : 2;
+  return `${size.toFixed(digits)} ${units[unitIndex]}`;
+}
+
+class HealthView {
+  constructor() {
+    this.model = new HealthModel();
+  }
+
+  oninit() {
+    this.model.load();
+  }
+
+  _usageRows() {
+    const summary = this.model.summary;
+
+    return [
+      ["Filesystem", summary && summary.filesystem ? summary.filesystem : "-"],
+      ["Mountpoint", summary && summary.mountpoint ? summary.mountpoint : "-"],
+      ["Total size", summary ? formatBytes(summary.totalBytes) : "-"],
+      ["Used size", summary ? formatBytes(summary.usedBytes) : "-"],
+      ["Available size", summary ? formatBytes(summary.availableBytes) : "-"],
+      ["Used percent", summary && summary.usedPercent !== null ? `${summary.usedPercent.toFixed(1)}%` : "-"],
+      ["Last received (local)", summary ? timestamp2LocalTime(summary.lastReceivedAt) : "-"],
+      ["Last received (UTC)", summary ? timestamp2UtcTime(summary.lastReceivedAt) : "-"],
+    ];
+  }
+
+  _historyChartOptions() {
+    return {
+      type: "line",
+      data: {
+        labels: this.model.history.map(function (row) {
+          return timestamp2LocalTime(row.createdAt);
+        }),
+        datasets: [
+          {
+            label: "Used percent",
+            data: this.model.history.map(function (row) {
+              return row.usedPercent;
+            }),
+            fill: false,
+            tension: 0.25,
+          },
+        ],
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        plugins: {
+          colors: {
+            enabled: true,
+          },
+        },
+        scales: {
+          y: {
+            min: 0,
+            max: 100,
+            ticks: {
+              callback: function (value) {
+                return `${value}%`;
+              },
+            },
+          },
+        },
+      },
+    };
+  }
+
+  _usagePanel() {
+    return m(".col-sm-12.col-xl-6", [
+      m(".bg-light.rounded.h-100.p-4", [
+        m(".d-flex.align-items-center.justify-content-between.mb-4", m("h6.mb-0", "Disk Usage")),
+        this.model.summary && this.model.summary.stale
+          ? m(".alert.alert-warning.py-2.mb-4", "Telemetry is stale. The latest successful report is older than the expected reporting window.")
+          : null,
+        this.model.isNeverReported()
+          ? m(".health-empty-state.py-5.text-center", [
+              m("i.fa.fa-hdd.fa-2x.mb-3"),
+              m("h5.mb-2", "Never Reported"),
+              m(".text-muted", "No storage usage info exists yet. The chart and summary will populate after the first successful telemetry push."),
+            ])
+          : m(
+              "div.table-responsive",
+              m(
+                "table.table.table-sm.mb-0",
+                m(
+                  "tbody",
+                  this._usageRows().map(function (row) {
+                    return m("tr", [m("th", { scope: "row" }, row[0]), m("td.text-end", row[1])]);
+                  }),
+                ),
+              ),
+            ),
+      ]),
+    ]);
+  }
+
+  _historyPanel() {
+    return m(".col-sm-12.col-xl-6", [
+      m(".bg-light.rounded.h-100.p-4", [
+        m(".d-flex.align-items-center.justify-content-between.mb-4", m("h6.mb-0", "30-Day Disk History")),
+        this.model.isNeverReported()
+          ? m(".health-empty-state.py-5.text-center", [
+              m("i.fa.fa-chart-line.fa-2x.mb-3"),
+              m("h5.mb-2", "Never Reported"),
+              m(".text-muted", "No 30-day storage history is available."),
+            ])
+          : m(".health-chart-container", m(ChartComponent, { chartOptions: this._historyChartOptions() })),
+      ]),
+    ]);
+  }
+
+  view() {
+    return m(".container-fluid.pt-4.px-4", [
+      this.model.isLoading ? m(".bg-light.rounded.p-4.mb-4", "Loading system health...") : null,
+      this.model.error ? m(".alert.alert-danger.mb-4", this.model.error) : null,
+      this.model.summary ? m(".row.g-4", [this._usagePanel(), this._historyPanel()]) : null,
+    ]);
+  }
+}
+
+module.exports = HealthView;


### PR DESCRIPTION
## Summary
- Add a new authenticated `/health` page that shows current disk usage, stale telemetry warnings, and a 30-day usage chart.
- Add a sidebar entry and client-side model wiring to load disk utilization history from the API.
- Adjust the disk utilization history API payload and integration test expectations to return daily aggregated points with `date`, usage totals, and summary data for the UI.

## Scope
- Included: Health dashboard route, sidebar navigation, frontend model/view, API history aggregation shape updates, and related integration test adjustments.
- Not included: New alerting rules, ingestion pipeline changes, retention policy changes, or broader observability UX beyond disk utilization.

## Risks
- Low to moderate. This PR changes the history payload from `createdAt` to `date`; the frontend chart labels still read `row.createdAt`, so reviewer attention is needed on the chart data mapping.

## Links
- Jira: KAN-19
- Spec: TBD
