### PR TITLE
KAN-20: feat: add click summary to core campaigns list

### DIFF
--- a/apps/api/src/container.py
+++ b/apps/api/src/container.py
@@ -9,6 +9,7 @@ from src.alerts.services import AlertService
 from src.auth.services import AuthenticationService
 from src.core.db import database
 from src.core.entities import database_proxy
+from src.core.repositories import CampaignRepository
 from src.core.services import CampaignService, ClientService, FlowService, Ip2LocationLocator
 from src.core.supervisor import WorkerContext, WorkerSupervisor
 from src.facebook_pacs.services import AdCabinetService as FacebookPacsAdCabinetService
@@ -59,6 +60,7 @@ container = create_sync_container(
         StatisticsReportRepository,
         AlertService,
         AuthenticationService,
+        CampaignRepository,
         CampaignService,
         ClientService,
         FlowService,

--- a/apps/api/src/core/enums.py
+++ b/apps/api/src/core/enums.py
@@ -4,6 +4,9 @@ from enum import Enum
 class SortBy(str, Enum):
     id = 'id'
     createdAt = 'createdAt'
+    clickCount = 'clickCount'
+    clickShare = 'clickShare'
+    lastActivityAt = 'lastActivityAt'
 
 
 class SortOrder(str, Enum):

--- a/apps/api/src/core/repositories.py
+++ b/apps/api/src/core/repositories.py
@@ -8,15 +8,14 @@ from src.tracker.entities import TrackClick
 
 @injectable
 class CampaignRepository:
-    def get(self, campaign_id):
-        return self._campaigns_with_summary().where(Campaign.id == campaign_id).get_or_none()
-
     def list(self, page, page_size, sort_by, sort_order):
-        query = self._campaigns_with_summary()
+        query = Campaign.select()
 
         if sort_by in {'click_count', 'click_share'}:
+            query = self._campaigns_with_click_stats()
             order_by = SQL('click_count')
         elif sort_by == 'last_activity_at':
+            query = self._campaigns_with_click_stats()
             order_by = SQL('last_activity_at')
         else:
             order_by = getattr(Campaign, sort_by)
@@ -26,7 +25,7 @@ class CampaignRepository:
         else:
             order_by = order_by.asc()
 
-        return list(query.order_by(order_by, Campaign.id).limit(page_size).offset((page - 1) * page_size).dicts())
+        return list(query.order_by(order_by, Campaign.id).limit(page_size).offset((page - 1) * page_size))
 
     def all(self):
         return [campaign for campaign in Campaign.select()]
@@ -37,7 +36,28 @@ class CampaignRepository:
     def total_click_count(self):
         return TrackClick.select(fn.COUNT(TrackClick.id)).scalar()
 
-    def _campaigns_with_summary(self):
+    def get_click_stats(self, campaign_ids):
+        if len(campaign_ids) == 0:
+            return {}
+
+        return {
+            stats['campaign_id']: {
+                'click_count': stats['click_count'],
+                'last_activity_at': stats['last_activity_at'],
+            }
+            for stats in (
+                TrackClick.select(
+                    TrackClick.campaign_id.alias('campaign_id'),
+                    fn.COUNT(TrackClick.id).alias('click_count'),
+                    fn.MAX(TrackClick.created_at).alias('last_activity_at'),
+                )
+                .where(TrackClick.campaign_id.in_(campaign_ids))
+                .group_by(TrackClick.campaign_id)
+                .dicts()
+            )
+        }
+
+    def _campaigns_with_click_stats(self):
         clicks_subquery = (
             TrackClick.select(
                 TrackClick.campaign_id.alias('campaign_id'),

--- a/apps/api/src/core/repositories.py
+++ b/apps/api/src/core/repositories.py
@@ -1,0 +1,59 @@
+from peewee import JOIN, SQL, fn
+from wireup import injectable
+
+from src.core.entities import Campaign
+from src.core.enums import SortOrder
+from src.tracker.entities import TrackClick
+
+
+@injectable
+class CampaignRepository:
+    def get(self, campaign_id):
+        return self._campaigns_with_summary().where(Campaign.id == campaign_id).get_or_none()
+
+    def list(self, page, page_size, sort_by, sort_order):
+        query = self._campaigns_with_summary()
+
+        if sort_by in {'click_count', 'click_share'}:
+            order_by = SQL('click_count')
+        elif sort_by == 'last_activity_at':
+            order_by = SQL('last_activity_at')
+        else:
+            order_by = getattr(Campaign, sort_by)
+
+        if sort_order == SortOrder.desc:
+            order_by = order_by.desc()
+        else:
+            order_by = order_by.asc()
+
+        return list(query.order_by(order_by, Campaign.id).limit(page_size).offset((page - 1) * page_size).dicts())
+
+    def all(self):
+        return [campaign for campaign in Campaign.select()]
+
+    def count(self):
+        return Campaign.select(fn.count(Campaign.id)).scalar()
+
+    def total_click_count(self):
+        return TrackClick.select(fn.COUNT(TrackClick.id)).scalar()
+
+    def _campaigns_with_summary(self):
+        clicks_subquery = (
+            TrackClick.select(
+                TrackClick.campaign_id.alias('campaign_id'),
+                fn.COUNT(TrackClick.id).alias('click_count'),
+                fn.MAX(TrackClick.created_at).alias('last_activity_at'),
+            )
+            .group_by(TrackClick.campaign_id)
+            .alias('clicks_summary')
+        )
+
+        return Campaign.select(
+            Campaign,
+            fn.COALESCE(clicks_subquery.c.click_count, 0).alias('click_count'),
+            clicks_subquery.c.last_activity_at.alias('last_activity_at'),
+        ).join(
+            clicks_subquery,
+            JOIN.LEFT_OUTER,
+            on=(Campaign.id == clicks_subquery.c.campaign_id),
+        )

--- a/apps/api/src/core/routes.py
+++ b/apps/api/src/core/routes.py
@@ -44,8 +44,11 @@ class Campaigns(MethodView):
         return {
             'content': [
                 humps.camelize(
-                    c.to_dict()
-                    | {'internal_process_url': f'{container.config.get("INTERNAL_PROCESS_BASE_URL")}/{c.id}'}
+                    c
+                    | {
+                        'internal_process_url': f'{container.config.get("INTERNAL_PROCESS_BASE_URL")}/{c["id"]}',
+                        'summary': c["summary"],
+                    }
                 )
                 for c in campaigns
             ],
@@ -75,7 +78,10 @@ class Campaign(MethodView):
         campaign = campaign_service.get(campaignId)
         return humps.camelize(
             campaign.to_dict()
-            | {'internal_process_url': f'{container.config.get("INTERNAL_PROCESS_BASE_URL")}/{campaign.id}'}
+            | {
+                'internal_process_url': f'{container.config.get("INTERNAL_PROCESS_BASE_URL")}/{campaign.id}',
+                'summary': campaign.summary,
+            }
         )
 
     @blueprint.arguments(CampaignUpdateRequestSchema)

--- a/apps/api/src/core/routes.py
+++ b/apps/api/src/core/routes.py
@@ -26,6 +26,17 @@ from src.core.services import CampaignService, FlowService
 blueprint = Blueprint('core', __name__, description='Core')
 
 
+def _campaign_summary(campaign_id, click_stats, total_click_count):
+    stats = click_stats.get(campaign_id, {})
+    click_count = stats.get('click_count', 0)
+    last_activity_at = stats.get('last_activity_at')
+    return {
+        'click_count': click_count,
+        'click_share': click_count / total_click_count if total_click_count else 0.0,
+        'last_activity_at': int(last_activity_at.timestamp()) if last_activity_at else None,
+    }
+
+
 @blueprint.route('/campaigns')
 class Campaigns(MethodView):
     @blueprint.arguments(PaginationRequestSchema, location='query')
@@ -40,14 +51,16 @@ class Campaigns(MethodView):
             parameters_payload['sortOrder'],
         )
         count = campaign_service.count()
+        click_stats = campaign_service.get_click_stats([campaign.id for campaign in campaigns])
+        total_click_count = campaign_service.total_click_count()
 
         return {
             'content': [
                 humps.camelize(
-                    c
+                    c.to_dict()
                     | {
-                        'internal_process_url': f'{container.config.get("INTERNAL_PROCESS_BASE_URL")}/{c["id"]}',
-                        'summary': c["summary"],
+                        'internal_process_url': f'{container.config.get("INTERNAL_PROCESS_BASE_URL")}/{c.id}',
+                        'summary': _campaign_summary(c.id, click_stats, total_click_count),
                     }
                 )
                 for c in campaigns
@@ -76,11 +89,13 @@ class Campaign(MethodView):
     def get(self, campaignId):
         campaign_service = container.get(CampaignService)
         campaign = campaign_service.get(campaignId)
+        click_stats = campaign_service.get_click_stats([campaign.id])
+        total_click_count = campaign_service.total_click_count()
         return humps.camelize(
             campaign.to_dict()
             | {
                 'internal_process_url': f'{container.config.get("INTERNAL_PROCESS_BASE_URL")}/{campaign.id}',
-                'summary': campaign.summary,
+                'summary': _campaign_summary(campaign.id, click_stats, total_click_count),
             }
         )
 

--- a/apps/api/src/core/schemas.py
+++ b/apps/api/src/core/schemas.py
@@ -88,6 +88,12 @@ class CampaignUpdateRequestSchema(Schema):
         validate_status_mapper(data.get('statusMapper'))
 
 
+class CampaignSummaryResponseSchema(Schema):
+    clickCount = fields.Integer(required=True)
+    clickShare = fields.Float(required=True)
+    lastActivityAt = fields.Integer(allow_none=True)
+
+
 class CampaignResponseSchema(Schema):
     id = fields.Integer(required=True)
     name = fields.String(required=True)
@@ -97,13 +103,7 @@ class CampaignResponseSchema(Schema):
     statusMapper = fields.Dict(allow_none=True)
     internalProcessUrl = fields.String(allow_none=True)
     expensesDistributionParameter = fields.String(allow_none=True)
-    summary = fields.Nested(lambda: CampaignSummaryResponseSchema(), required=True)
-
-
-class CampaignSummaryResponseSchema(Schema):
-    clickCount = fields.Integer(required=True)
-    clickShare = fields.Float(required=True)
-    lastActivityAt = fields.Integer(allow_none=True)
+    summary = fields.Nested(CampaignSummaryResponseSchema(), required=True)
 
 
 class CampaignListResponseSchema(Schema):

--- a/apps/api/src/core/schemas.py
+++ b/apps/api/src/core/schemas.py
@@ -97,6 +97,13 @@ class CampaignResponseSchema(Schema):
     statusMapper = fields.Dict(allow_none=True)
     internalProcessUrl = fields.String(allow_none=True)
     expensesDistributionParameter = fields.String(allow_none=True)
+    summary = fields.Nested(lambda: CampaignSummaryResponseSchema(), required=True)
+
+
+class CampaignSummaryResponseSchema(Schema):
+    clickCount = fields.Integer(required=True)
+    clickShare = fields.Float(required=True)
+    lastActivityAt = fields.Integer(allow_none=True)
 
 
 class CampaignListResponseSchema(Schema):

--- a/apps/api/src/core/services.py
+++ b/apps/api/src/core/services.py
@@ -1,4 +1,3 @@
-import dataclasses
 import logging
 import os
 import shutil
@@ -17,6 +16,7 @@ from src.core.entities import Campaign, Flow
 from src.core.enums import FlowActionType, SortOrder
 from src.core.exceptions import CampaignDoesNotExistError, DoesNotExistError, LandingPageUploadError
 from src.core.models import Client
+from src.core.repositories import CampaignRepository
 from src.core.utils import log_execution_time
 
 logger = logging.getLogger(__name__)
@@ -70,21 +70,25 @@ class ClientService:
 
 @injectable
 class CampaignService:
+    def __init__(self, campaign_repository: CampaignRepository):
+        self.campaign_repository = campaign_repository
+
     def get(self, id):
-        try:
-            return Campaign.get_by_id(id)
-        except Campaign.DoesNotExist as exc:
-            raise CampaignDoesNotExistError() from exc
+        campaign = self.campaign_repository.get(id)
+        if campaign is None:
+            raise CampaignDoesNotExistError()
+        self._attach_summary(campaign, self.campaign_repository.total_click_count())
+        return campaign
 
     def list(self, page, page_size, sort_by, sort_order):
-        order_by = getattr(Campaign, sort_by)
-        if sort_order == SortOrder.desc:
-            order_by = order_by.desc()
-
-        return [c for c in Campaign.select().order_by(order_by).limit(page_size).offset((page - 1) * page_size)]
+        campaigns = self.campaign_repository.list(page, page_size, sort_by, sort_order)
+        total_click_count = self.campaign_repository.total_click_count()
+        for campaign in campaigns:
+            self._attach_summary(campaign, total_click_count)
+        return campaigns
 
     def all(self):
-        return [c for c in Campaign.select()]
+        return self.campaign_repository.all()
 
     def create(self, name, cost_model, cost_value, currency, status_mapper=None):
         campaign = Campaign(
@@ -120,7 +124,15 @@ class CampaignService:
         return campaign
 
     def count(self):
-        return Campaign.select(fn.count(Campaign.id)).scalar()
+        return self.campaign_repository.count()
+
+    def _attach_summary(self, campaign, total_click_count):
+        click_count = campaign['click_count'] or 0
+        campaign['summary'] = {
+            'click_count': click_count,
+            'click_share': click_count / total_click_count if total_click_count else 0.0,
+            'last_activity_at': campaign['last_activity_at'],
+        }
 
 
 @injectable

--- a/apps/api/src/core/services.py
+++ b/apps/api/src/core/services.py
@@ -1,3 +1,4 @@
+import dataclasses
 import logging
 import os
 import shutil
@@ -74,21 +75,16 @@ class CampaignService:
         self.campaign_repository = campaign_repository
 
     def get(self, id):
-        campaign = self.campaign_repository.get(id)
-        if campaign is None:
-            raise CampaignDoesNotExistError()
-        self._attach_summary(campaign, self.campaign_repository.total_click_count())
-        return campaign
+        try:
+            return Campaign.get_by_id(id)
+        except Campaign.DoesNotExist as exc:
+            raise CampaignDoesNotExistError() from exc
 
     def list(self, page, page_size, sort_by, sort_order):
-        campaigns = self.campaign_repository.list(page, page_size, sort_by, sort_order)
-        total_click_count = self.campaign_repository.total_click_count()
-        for campaign in campaigns:
-            self._attach_summary(campaign, total_click_count)
-        return campaigns
+        return self.campaign_repository.list(page, page_size, sort_by, sort_order)
 
     def all(self):
-        return self.campaign_repository.all()
+        return [c for c in Campaign.select()]
 
     def create(self, name, cost_model, cost_value, currency, status_mapper=None):
         campaign = Campaign(
@@ -102,7 +98,10 @@ class CampaignService:
         return campaign
 
     def update(self, campaign_id, name=None, cost_model=None, cost_value=None, currency=None, status_mapper=None):
-        campaign = self.get(campaign_id)
+        try:
+            campaign = Campaign.get_by_id(campaign_id)
+        except Campaign.DoesNotExist as exc:
+            raise CampaignDoesNotExistError() from exc
 
         if name:
             campaign.name = name
@@ -126,13 +125,11 @@ class CampaignService:
     def count(self):
         return self.campaign_repository.count()
 
-    def _attach_summary(self, campaign, total_click_count):
-        click_count = campaign['click_count'] or 0
-        campaign['summary'] = {
-            'click_count': click_count,
-            'click_share': click_count / total_click_count if total_click_count else 0.0,
-            'last_activity_at': campaign['last_activity_at'],
-        }
+    def get_click_stats(self, campaign_ids):
+        return self.campaign_repository.get_click_stats(campaign_ids)
+
+    def total_click_count(self):
+        return self.campaign_repository.total_click_count()
 
 
 @injectable

--- a/apps/api/tests/integration/core/test_campaigns.py
+++ b/apps/api/tests/integration/core/test_campaigns.py
@@ -3,6 +3,8 @@ from unittest import mock
 
 import pytest
 
+from tests.fixtures.utils import click_uuid
+
 
 def test_create_campaign(client, authorization, campaign_payload, read_from_db):
     campaigns = read_from_db('campaign', fetchall=True)
@@ -36,24 +38,32 @@ def test_create_campaign(client, authorization, campaign_payload, read_from_db):
 
 
 def test_campaigns_list(client, authorization, environment, campaign_payload, write_to_db):
+    campaigns = []
     for ci in range(25):
-        write_to_db('campaign', {'name': f'Campaign {ci}', 'cost_model': 'cpm', 'cost_value': 1, 'currency': 'usd'})
+        campaigns.append(
+            write_to_db('campaign', {'name': f'Campaign {ci}', 'cost_model': 'cpm', 'cost_value': 1, 'currency': 'usd'})
+        )
 
     response = client.get('/api/v2/core/campaigns', headers={'Authorization': authorization})
     assert response.status_code == 200, response.text
     assert response.json == {
         'content': [
             {
-                'costModel': 'cpm',
-                'costValue': 1.0,
-                'currency': 'usd',
-                'expensesDistributionParameter': None,
-                'id': index + 1,
-                'name': f'Campaign {index}',
-                'internalProcessUrl': f'{environment["INTERNAL_PROCESS_BASE_URL"]}/{index + 1}',
-                'statusMapper': None,
+                'costModel': campaign['cost_model'],
+                'costValue': campaign['cost_value'],
+                'currency': campaign['currency'],
+                'expensesDistributionParameter': campaign['expenses_distribution_parameter'],
+                'id': campaign['id'],
+                'name': campaign['name'],
+                'internalProcessUrl': f'{environment["INTERNAL_PROCESS_BASE_URL"]}/{campaign["id"]}',
+                'summary': {
+                    'clickCount': 0,
+                    'clickShare': 0.0,
+                    'lastActivityAt': None,
+                },
+                'statusMapper': campaign['status_mapper'],
             }
-            for index in range(20)
+            for campaign in campaigns[:20]
         ],
         'pagination': {'page': 1, 'pageSize': 20, 'sortBy': 'id', 'sortOrder': 'asc', 'total': 25},
     }
@@ -71,6 +81,11 @@ def test_get_campaign(client, authorization, campaign, environment):
         'currency': campaign['currency'],
         'expensesDistributionParameter': campaign['expenses_distribution_parameter'],
         'internalProcessUrl': f'{environment["INTERNAL_PROCESS_BASE_URL"]}/{campaign["id"]}',
+        'summary': {
+            'clickCount': 0,
+            'clickShare': 0.0,
+            'lastActivityAt': None,
+        },
         'statusMapper': json.loads(campaign['status_mapper']),
     }
 
@@ -104,3 +119,320 @@ def test_update_campaign(client, authorization, campaign, read_from_db, request_
 
     campaign = read_from_db('campaign')
     assert campaign[db_key] == request_value
+
+
+def test_campaigns_list__returns_click_summary(
+    client,
+    authorization,
+    environment,
+    timestamp,
+    write_to_db,
+):
+    first_campaign = write_to_db(
+        'campaign', {'name': 'Campaign 1', 'cost_model': 'cpm', 'cost_value': 1, 'currency': 'usd'}
+    )
+    second_campaign = write_to_db(
+        'campaign',
+        {'name': 'Campaign 2', 'cost_model': 'cpm', 'cost_value': 1, 'currency': 'usd'},
+    )
+    idle_campaign = write_to_db(
+        'campaign', {'name': 'Campaign 3', 'cost_model': 'cpm', 'cost_value': 1, 'currency': 'usd'}
+    )
+
+    write_to_db(
+        'track_click',
+        {
+            'campaign_id': first_campaign['id'],
+            'click_id': click_uuid(1),
+            'parameters': {},
+            'created_at': timestamp - 20,
+        },
+    )
+    write_to_db(
+        'track_click',
+        {
+            'campaign_id': first_campaign['id'],
+            'click_id': click_uuid(2),
+            'parameters': {},
+            'created_at': timestamp - 10,
+        },
+    )
+    write_to_db(
+        'track_click',
+        {
+            'campaign_id': second_campaign['id'],
+            'click_id': click_uuid(3),
+            'parameters': {},
+            'created_at': timestamp - 5,
+        },
+    )
+
+    response = client.get('/api/v2/core/campaigns', headers={'Authorization': authorization})
+
+    assert response.status_code == 200, response.text
+    assert response.json == {
+        'content': [
+            {
+                'costModel': first_campaign['cost_model'],
+                'costValue': first_campaign['cost_value'],
+                'currency': first_campaign['currency'],
+                'expensesDistributionParameter': first_campaign['expenses_distribution_parameter'],
+                'id': first_campaign['id'],
+                'name': first_campaign['name'],
+                'internalProcessUrl': f'{environment["INTERNAL_PROCESS_BASE_URL"]}/{first_campaign["id"]}',
+                'summary': {
+                    'clickCount': 2,
+                    'clickShare': pytest.approx(2 / 3),
+                    'lastActivityAt': timestamp - 10,
+                },
+                'statusMapper': first_campaign['status_mapper'],
+            },
+            {
+                'costModel': second_campaign['cost_model'],
+                'costValue': second_campaign['cost_value'],
+                'currency': second_campaign['currency'],
+                'expensesDistributionParameter': second_campaign['expenses_distribution_parameter'],
+                'id': second_campaign['id'],
+                'name': second_campaign['name'],
+                'internalProcessUrl': f'{environment["INTERNAL_PROCESS_BASE_URL"]}/{second_campaign["id"]}',
+                'summary': {
+                    'clickCount': 1,
+                    'clickShare': pytest.approx(1 / 3),
+                    'lastActivityAt': timestamp - 5,
+                },
+                'statusMapper': second_campaign['status_mapper'],
+            },
+            {
+                'costModel': idle_campaign['cost_model'],
+                'costValue': idle_campaign['cost_value'],
+                'currency': idle_campaign['currency'],
+                'expensesDistributionParameter': idle_campaign['expenses_distribution_parameter'],
+                'id': idle_campaign['id'],
+                'name': idle_campaign['name'],
+                'internalProcessUrl': f'{environment["INTERNAL_PROCESS_BASE_URL"]}/{idle_campaign["id"]}',
+                'summary': {
+                    'clickCount': 0,
+                    'clickShare': 0.0,
+                    'lastActivityAt': None,
+                },
+                'statusMapper': idle_campaign['status_mapper'],
+            },
+        ],
+        'pagination': {'page': 1, 'pageSize': 20, 'sortBy': 'id', 'sortOrder': 'asc', 'total': 3},
+    }
+
+
+def test_get_campaign__returns_click_summary(client, authorization, campaign, environment, timestamp, write_to_db):
+    write_to_db(
+        'track_click',
+        {
+            'campaign_id': campaign['id'],
+            'click_id': click_uuid(1),
+            'parameters': {},
+            'created_at': timestamp - 100,
+        },
+    )
+    write_to_db(
+        'track_click',
+        {
+            'campaign_id': campaign['id'],
+            'click_id': click_uuid(2),
+            'parameters': {},
+            'created_at': timestamp - 1,
+        },
+    )
+
+    response = client.get(f'/api/v2/core/campaigns/{campaign["id"]}', headers={'Authorization': authorization})
+
+    assert response.status_code == 200, response.text
+    assert response.json == {
+        'id': campaign['id'],
+        'name': campaign['name'],
+        'costModel': campaign['cost_model'],
+        'costValue': campaign['cost_value'],
+        'currency': campaign['currency'],
+        'expensesDistributionParameter': campaign['expenses_distribution_parameter'],
+        'internalProcessUrl': f'{environment["INTERNAL_PROCESS_BASE_URL"]}/{campaign["id"]}',
+        'summary': {
+            'clickCount': 2,
+            'clickShare': 1.0,
+            'lastActivityAt': timestamp - 1,
+        },
+        'statusMapper': json.loads(campaign['status_mapper']),
+    }
+
+
+def test_campaigns_list__sorts_by_click_share(client, authorization, environment, timestamp, write_to_db):
+    high_share_campaign = write_to_db(
+        'campaign',
+        {'name': 'High share', 'cost_model': 'cpm', 'cost_value': 1, 'currency': 'usd'},
+    )
+    low_share_campaign = write_to_db(
+        'campaign',
+        {'name': 'Low share', 'cost_model': 'cpm', 'cost_value': 1, 'currency': 'usd'},
+    )
+    no_clicks_campaign = write_to_db(
+        'campaign',
+        {'name': 'No clicks', 'cost_model': 'cpm', 'cost_value': 1, 'currency': 'usd'},
+    )
+
+    for click_id, created_at in (
+        (click_uuid(1), timestamp - 30),
+        (click_uuid(2), timestamp - 20),
+        (click_uuid(3), timestamp - 10),
+    ):
+        write_to_db(
+            'track_click',
+            {
+                'campaign_id': high_share_campaign['id'],
+                'click_id': click_id,
+                'parameters': {},
+                'created_at': created_at,
+            },
+        )
+
+    write_to_db(
+        'track_click',
+        {
+            'campaign_id': low_share_campaign['id'],
+            'click_id': click_uuid(4),
+            'parameters': {},
+            'created_at': timestamp - 5,
+        },
+    )
+
+    response = client.get(
+        '/api/v2/core/campaigns?page=1&pageSize=20&sortBy=clickShare&sortOrder=desc',
+        headers={'Authorization': authorization},
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json == {
+        'content': [
+            {
+                'costModel': high_share_campaign['cost_model'],
+                'costValue': high_share_campaign['cost_value'],
+                'currency': high_share_campaign['currency'],
+                'expensesDistributionParameter': high_share_campaign['expenses_distribution_parameter'],
+                'id': high_share_campaign['id'],
+                'name': high_share_campaign['name'],
+                'internalProcessUrl': f'{environment["INTERNAL_PROCESS_BASE_URL"]}/{high_share_campaign["id"]}',
+                'summary': {
+                    'clickCount': 3,
+                    'clickShare': 0.75,
+                    'lastActivityAt': timestamp - 10,
+                },
+                'statusMapper': high_share_campaign['status_mapper'],
+            },
+            {
+                'costModel': low_share_campaign['cost_model'],
+                'costValue': low_share_campaign['cost_value'],
+                'currency': low_share_campaign['currency'],
+                'expensesDistributionParameter': low_share_campaign['expenses_distribution_parameter'],
+                'id': low_share_campaign['id'],
+                'name': low_share_campaign['name'],
+                'internalProcessUrl': f'{environment["INTERNAL_PROCESS_BASE_URL"]}/{low_share_campaign["id"]}',
+                'summary': {
+                    'clickCount': 1,
+                    'clickShare': 0.25,
+                    'lastActivityAt': timestamp - 5,
+                },
+                'statusMapper': low_share_campaign['status_mapper'],
+            },
+            {
+                'costModel': no_clicks_campaign['cost_model'],
+                'costValue': no_clicks_campaign['cost_value'],
+                'currency': no_clicks_campaign['currency'],
+                'expensesDistributionParameter': no_clicks_campaign['expenses_distribution_parameter'],
+                'id': no_clicks_campaign['id'],
+                'name': no_clicks_campaign['name'],
+                'internalProcessUrl': f'{environment["INTERNAL_PROCESS_BASE_URL"]}/{no_clicks_campaign["id"]}',
+                'summary': {
+                    'clickCount': 0,
+                    'clickShare': 0.0,
+                    'lastActivityAt': None,
+                },
+                'statusMapper': no_clicks_campaign['status_mapper'],
+            },
+        ],
+        'pagination': {'page': 1, 'pageSize': 20, 'sortBy': 'clickShare', 'sortOrder': 'desc', 'total': 3},
+    }
+
+
+def test_campaigns_list__sorts_by_last_activity_at(client, authorization, environment, timestamp, write_to_db):
+    newest_campaign = write_to_db(
+        'campaign',
+        {'name': 'Newest activity', 'cost_model': 'cpm', 'cost_value': 1, 'currency': 'usd'},
+    )
+    older_campaign = write_to_db(
+        'campaign',
+        {'name': 'Older activity', 'cost_model': 'cpm', 'cost_value': 1, 'currency': 'usd'},
+    )
+    no_activity_campaign = write_to_db(
+        'campaign',
+        {'name': 'No activity', 'cost_model': 'cpm', 'cost_value': 1, 'currency': 'usd'},
+    )
+
+    write_to_db(
+        'track_click',
+        {
+            'campaign_id': newest_campaign['id'],
+            'click_id': click_uuid(1),
+            'parameters': {},
+            'created_at': timestamp - 1,
+        },
+    )
+    write_to_db(
+        'track_click',
+        {
+            'campaign_id': older_campaign['id'],
+            'click_id': click_uuid(2),
+            'parameters': {},
+            'created_at': timestamp - 100,
+        },
+    )
+
+    response = client.get(
+        '/api/v2/core/campaigns?page=1&pageSize=20&sortBy=lastActivityAt&sortOrder=desc',
+        headers={'Authorization': authorization},
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json == {
+        'content': [
+            {
+                'costModel': newest_campaign['cost_model'],
+                'costValue': newest_campaign['cost_value'],
+                'currency': newest_campaign['currency'],
+                'expensesDistributionParameter': newest_campaign['expenses_distribution_parameter'],
+                'id': newest_campaign['id'],
+                'internalProcessUrl': f'{environment["INTERNAL_PROCESS_BASE_URL"]}/{newest_campaign["id"]}',
+                'name': newest_campaign['name'],
+                'statusMapper': newest_campaign['status_mapper'],
+                'summary': {'clickCount': 1, 'clickShare': 0.5, 'lastActivityAt': timestamp - 1},
+            },
+            {
+                'costModel': older_campaign['cost_model'],
+                'costValue': older_campaign['cost_value'],
+                'currency': older_campaign['currency'],
+                'expensesDistributionParameter': older_campaign['expenses_distribution_parameter'],
+                'id': older_campaign['id'],
+                'internalProcessUrl': f'{environment["INTERNAL_PROCESS_BASE_URL"]}/{older_campaign["id"]}',
+                'name': older_campaign['name'],
+                'statusMapper': older_campaign['status_mapper'],
+                'summary': {'clickCount': 1, 'clickShare': 0.5, 'lastActivityAt': timestamp - 100},
+            },
+            {
+                'costModel': no_activity_campaign['cost_model'],
+                'costValue': no_activity_campaign['cost_value'],
+                'currency': no_activity_campaign['currency'],
+                'expensesDistributionParameter': no_activity_campaign['expenses_distribution_parameter'],
+                'id': no_activity_campaign['id'],
+                'internalProcessUrl': f'{environment["INTERNAL_PROCESS_BASE_URL"]}/{no_activity_campaign["id"]}',
+                'name': no_activity_campaign['name'],
+                'statusMapper': no_activity_campaign['status_mapper'],
+                'summary': {'clickCount': 0, 'clickShare': 0.0, 'lastActivityAt': None},
+            },
+        ],
+        'pagination': {'page': 1, 'pageSize': 20, 'sortBy': 'lastActivityAt', 'sortOrder': 'desc', 'total': 3},
+    }

--- a/apps/web/src/views/core_campaigns.js
+++ b/apps/web/src/views/core_campaigns.js
@@ -45,6 +45,9 @@ class CoreCampaignsView {
                           m("th", { scope: "col" }, "Cost Model"),
                           m("th", { scope: "col" }, "Cost Value"),
                           m("th", { scope: "col" }, "Currency"),
+                          m("th", { scope: "col" }, "Clicks"),
+                          m("th", { scope: "col" }, "Click Share"),
+                          m("th", { scope: "col" }, "Last Activity"),
                         ]),
                       ),
                       m(
@@ -53,7 +56,7 @@ class CoreCampaignsView {
                           ? m("tr", [
                               m(
                                 "td.text-center",
-                                { colspan: 5 },
+                                { colspan: 8 },
                                 "No campaigns found.",
                               ),
                             ])
@@ -71,6 +74,14 @@ class CoreCampaignsView {
                                 m("td", campaign.costModel),
                                 m("td", campaign.costValue),
                                 m("td", campaign.currency),
+                                m("td", campaign.summary ? campaign.summary.clickCount : "-"),
+                                m("td", campaign.summary ? campaign.summary.clickShare : "-"),
+                                m(
+                                  "td",
+                                  campaign.summary
+                                    ? timestamp2LocalTime(campaign.summary.lastActivityAt)
+                                    : "-",
+                                ),
                               ]);
                             }),
                       ),

--- a/apps/web/src/views/core_campaigns.js
+++ b/apps/web/src/views/core_campaigns.js
@@ -1,6 +1,7 @@
 let m = require("mithril");
 let CoreCampaignsModel = require("../models/core_campaigns");
 let Pagination = require("../components/pagination");
+let { timestamp2LocalTime } = require("../utils/date");
 
 class CoreCampaignsView {
   constructor(vnode) {


### PR DESCRIPTION
## Summary
- add click summary data to core campaign API responses
- support sorting campaigns by click count, click share, and last activity
- show clicks, click share, and last activity columns in the core campaigns list view

## Scope
- Included: new campaign repository-backed summary aggregation, API schema/route updates, campaigns list UI columns, integration test coverage for summary and sorting behavior
- Not included: changes to non-core campaign pages, backfill tooling for historical click data, formatting/polish for click share display beyond exposing the raw value

## Risks
- Low to moderate: campaign list responses now depend on an aggregate join over `track_click`, so large datasets may need follow-up query tuning if list latency increases.

## Links
- Jira: KAN-20
- Spec: TBD
