### PR TITLE
KAN-24: feat: create installer skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,6 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
 lib64/
 parts/
 sdist/

--- a/README.md
+++ b/README.md
@@ -47,3 +47,8 @@ Or work directly inside `apps/web`.
 - Shared runtime/service configuration lives under `infra/`
 - BMAD/spec/process assets live at the repository root
 - Cross-stack feature PRs are allowed, but the app boundaries stay explicit
+
+## Host Provisioning
+
+Fresh Ubuntu 24.04 LTS host installation starts from the pinned installer documented in
+[docs/host-provisioning.md](docs/host-provisioning.md).

--- a/docs/host-provisioning.md
+++ b/docs/host-provisioning.md
@@ -1,0 +1,24 @@
+# Bangi Host Provisioning
+
+The Bangi host provisioner installs a pinned Bangi release onto a fresh Ubuntu 24.04 LTS host.
+
+## Install Command
+
+Download the pinned installer to `/tmp` and run it with root privileges:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/devalentino/bangi/vX.Y.Z/infra/installer/install.sh -o /tmp/bangi-install.sh
+sudo bash /tmp/bangi-install.sh
+```
+
+The installer must run as root and validates Ubuntu 24.04 LTS before any package installation phase starts.
+
+## Manual Verification
+
+Installer behavior is verified manually on host environments for the MVP. Automated installer test coverage is out of scope.
+
+For the installer skeleton, verify:
+
+- running without root privileges fails before host changes
+- running on a non-Ubuntu 24.04 host fails before package installation
+- running on Ubuntu 24.04 as root reaches the installer phase orchestration

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,6 +37,7 @@ Bangi is a monorepo for a CPA tracking product. The backend exposes a Flask API 
 - [Source Tree Analysis](./source-tree-analysis.md) - Directory map and critical folders
 - [Project Parts Metadata](./project-parts.json) - Machine-readable monorepo structure
 - [Project Scan State](./project-scan-report.json) - Workflow state for future refreshes
+- [Host Provisioning](./host-provisioning.md) - Installer command and host provisioning entry point
 
 ## Existing Documentation
 

--- a/infra/installer/install.sh
+++ b/infra/installer/install.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+BANGI_RELEASE_TAG="vX.Y.Z"
+
+INSTALLER_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=infra/installer/lib/common.sh
+source "${INSTALLER_DIR}/lib/common.sh"
+# shellcheck source=infra/installer/lib/os.sh
+source "${INSTALLER_DIR}/lib/os.sh"
+# shellcheck source=infra/installer/lib/paths.sh
+source "${INSTALLER_DIR}/lib/paths.sh"
+# shellcheck source=infra/installer/lib/packages.sh
+source "${INSTALLER_DIR}/lib/packages.sh"
+# shellcheck source=infra/installer/lib/assets.sh
+source "${INSTALLER_DIR}/lib/assets.sh"
+# shellcheck source=infra/installer/lib/env.sh
+source "${INSTALLER_DIR}/lib/env.sh"
+# shellcheck source=infra/installer/lib/compose.sh
+source "${INSTALLER_DIR}/lib/compose.sh"
+# shellcheck source=infra/installer/lib/nginx.sh
+source "${INSTALLER_DIR}/lib/nginx.sh"
+# shellcheck source=infra/installer/lib/cron.sh
+source "${INSTALLER_DIR}/lib/cron.sh"
+# shellcheck source=infra/installer/lib/ops_user.sh
+source "${INSTALLER_DIR}/lib/ops_user.sh"
+# shellcheck source=infra/installer/lib/health.sh
+source "${INSTALLER_DIR}/lib/health.sh"
+
+main() {
+    bangi_require_root
+    bangi_validate_supported_os
+
+    bangi_log "Starting Bangi host provisioning for ${BANGI_RELEASE_TAG}"
+    bangi_verify_inputs
+    bangi_detect_existing_state
+    bangi_install_packages
+    bangi_create_paths
+    bangi_fetch_assets
+    bangi_write_environment
+    bangi_install_compose
+    bangi_install_nginx
+    bangi_install_ops_user
+    bangi_install_cron
+    bangi_start_compose
+    bangi_verify_health
+    bangi_activate_release
+    bangi_print_summary
+}
+
+main "$@"

--- a/infra/installer/lib/assets.sh
+++ b/infra/installer/lib/assets.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+BANGI_GITHUB_OWNER="devalentino"
+BANGI_GITHUB_REPO="bangi"
+BANGI_RAW_BASE_URL="https://raw.githubusercontent.com/${BANGI_GITHUB_OWNER}/${BANGI_GITHUB_REPO}/${BANGI_RELEASE_TAG}"
+
+bangi_raw_asset_url() {
+    local asset_path="$1"
+    printf '%s/%s\n' "${BANGI_RAW_BASE_URL}" "${asset_path}"
+}
+
+bangi_fetch_assets() {
+    bangi_log "Asset fetch phase pending implementation"
+}

--- a/infra/installer/lib/common.sh
+++ b/infra/installer/lib/common.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+bangi_log() {
+    printf '[bangi] %s\n' "$*"
+}
+
+bangi_fatal() {
+    printf '[bangi] ERROR: %s\n' "$*" >&2
+    exit 1
+}
+
+bangi_require_root() {
+    if [[ "${EUID}" -ne 0 ]]; then
+        bangi_fatal "Bangi installer must be run as root. Use: sudo bash /tmp/bangi-install.sh"
+    fi
+}
+
+bangi_verify_inputs() {
+    bangi_log "Input validation phase pending implementation"
+}
+
+bangi_detect_existing_state() {
+    bangi_log "Existing host state detection phase pending implementation"
+}
+
+bangi_print_summary() {
+    bangi_log "Bangi installer skeleton completed for ${BANGI_RELEASE_TAG}"
+}

--- a/infra/installer/lib/compose.sh
+++ b/infra/installer/lib/compose.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+bangi_install_compose() {
+    bangi_log "Compose installation phase pending implementation"
+}
+
+bangi_start_compose() {
+    bangi_log "Compose startup phase pending implementation"
+}

--- a/infra/installer/lib/cron.sh
+++ b/infra/installer/lib/cron.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+bangi_install_cron() {
+    bangi_log "Cron installation phase pending implementation"
+}

--- a/infra/installer/lib/env.sh
+++ b/infra/installer/lib/env.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+bangi_write_environment() {
+    bangi_log "Environment file phase pending implementation"
+}

--- a/infra/installer/lib/health.sh
+++ b/infra/installer/lib/health.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+bangi_verify_health() {
+    bangi_log "Health verification phase pending implementation"
+}

--- a/infra/installer/lib/nginx.sh
+++ b/infra/installer/lib/nginx.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+bangi_install_nginx() {
+    bangi_log "Nginx installation phase pending implementation"
+}

--- a/infra/installer/lib/ops_user.sh
+++ b/infra/installer/lib/ops_user.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+bangi_install_ops_user() {
+    bangi_log "Operations user phase pending implementation"
+}

--- a/infra/installer/lib/os.sh
+++ b/infra/installer/lib/os.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+bangi_validate_supported_os() {
+    local os_release_path="${1:-/etc/os-release}"
+    local os_id=""
+    local version_id=""
+
+    if [[ ! -r "${os_release_path}" ]]; then
+        bangi_fatal "Unsupported operating system: cannot read ${os_release_path}. Bangi requires Ubuntu 24.04 LTS."
+    fi
+
+    # shellcheck disable=SC1090
+    source "${os_release_path}"
+    os_id="${ID:-}"
+    version_id="${VERSION_ID:-}"
+
+    if [[ "${os_id}" != "ubuntu" || "${version_id}" != "24.04" ]]; then
+        bangi_fatal "Unsupported operating system: Bangi requires Ubuntu 24.04 LTS."
+    fi
+
+    bangi_log "Validated Ubuntu 24.04 LTS host"
+}

--- a/infra/installer/lib/packages.sh
+++ b/infra/installer/lib/packages.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+bangi_install_packages() {
+    bangi_log "Package installation phase pending implementation"
+}

--- a/infra/installer/lib/paths.sh
+++ b/infra/installer/lib/paths.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+BANGI_ROOT_DIR="/opt/bangi"
+BANGI_RELEASE_DIR="${BANGI_ROOT_DIR}/${BANGI_RELEASE_TAG}"
+BANGI_CURRENT_LINK="${BANGI_ROOT_DIR}/current"
+BANGI_SHARED_DIR="${BANGI_ROOT_DIR}/shared"
+BANGI_SHARED_ENV_DIR="${BANGI_SHARED_DIR}/env"
+BANGI_SHARED_MARIADB_DIR="${BANGI_SHARED_DIR}/mariadb"
+BANGI_SHARED_LANDINGS_DIR="${BANGI_SHARED_DIR}/landings"
+BANGI_SHARED_IP2LOCATION_DIR="${BANGI_SHARED_DIR}/ip2location"
+BANGI_OPS_BIN_DIR="${BANGI_ROOT_DIR}/ops/bin"
+BANGI_ETC_DIR="/etc/bangi"
+BANGI_NGINX_AVAILABLE_DIR="/etc/nginx/bangi/sites-available"
+BANGI_NGINX_ENABLED_DIR="/etc/nginx/bangi/sites-enabled"
+BANGI_LOG_DIR="/var/log/bangi"
+
+bangi_create_paths() {
+    bangi_log "Path creation phase pending implementation"
+}
+
+bangi_activate_release() {
+    bangi_log "Release activation phase pending implementation"
+}


### PR DESCRIPTION
## Summary
- Adds the Bangi installer entry point with pinned `BANGI_RELEASE_TAG`.
- Adds shared shell modules under `infra/installer/lib/` for installer phase orchestration.
- Documents the `/tmp` curl download flow and manual installer verification expectations.

## Scope
- Included: installer skeleton, root/Ubuntu 24.04 validation modules, phase module placeholders, host provisioning docs, documentation index links.
- Not included: package installation implementation, host filesystem mutation phases, Docker/Nginx/cron setup, automated installer test coverage.

## Risks
- Low for application runtime because this adds installer scaffolding only. Installer behavior still requires manual host verification per KAN-24 scope.

## Links
- Jira: https://bangitech.atlassian.net/browse/KAN-24
- Spec: `_bmad-output/planning-artifacts/epics.md` and `_bmad-output/planning-artifacts/bangi-host-provisioner-tech-spec.md`
