### PR TITLE
KAN-27: feat: publish release-tagged application images

### DIFF
--- a/.github/workflows/pr-pipelines.yaml
+++ b/.github/workflows/pr-pipelines.yaml
@@ -2,6 +2,65 @@ name: PR Pipelines
 run-name: Tests check on
 on: [pull_request]
 jobs:
+  release-version:
+    name: Release version check
+    if: github.base_ref == 'master'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Validate release tag bump
+        run: |
+          set -euo pipefail
+
+          if git diff --quiet "origin/${{ github.base_ref }}" -- infra/installer/install.sh; then
+            echo "infra/installer/install.sh was not changed; skipping release version check."
+            exit 0
+          fi
+
+          release_tag="$(sed -n 's/^BANGI_RELEASE_TAG="\([^"]*\)"$/\1/p' infra/installer/install.sh)"
+          base_release_tag="$(git show "origin/${{ github.base_ref }}:infra/installer/install.sh" | sed -n 's/^BANGI_RELEASE_TAG="\([^"]*\)"$/\1/p')"
+
+          if [[ -z "${release_tag}" ]]; then
+            echo "BANGI_RELEASE_TAG is missing from infra/installer/install.sh" >&2
+            exit 1
+          fi
+
+          if [[ ! "${release_tag}" =~ ^[0-9]+\.[0-9]+\.[0-9]+([ab][0-9]+)?$ ]]; then
+            echo "BANGI_RELEASE_TAG must use X.Y.Z, X.Y.ZaN, or X.Y.ZbN format" >&2
+            exit 1
+          fi
+
+          if [[ "${release_tag}" == "${base_release_tag}" ]]; then
+            echo "BANGI_RELEASE_TAG must be bumped from ${base_release_tag}" >&2
+            exit 1
+          fi
+
+          backend_image_tag="$(sed -n 's/^[[:space:]]*image: ghcr.io\/devalentino\/bangi-backend:\([^[:space:]]*\)$/\1/p' infra/installer/templates/compose.prod.yml)"
+          ui_image_tag="$(sed -n 's/^[[:space:]]*image: ghcr.io\/devalentino\/bangi-ui:\([^[:space:]]*\)$/\1/p' infra/installer/templates/compose.prod.yml)"
+
+          if [[ -z "${backend_image_tag}" || -z "${ui_image_tag}" ]]; then
+            echo "Production compose must define backend and UI GHCR image tags" >&2
+            exit 1
+          fi
+
+          if [[ "${backend_image_tag}" != "${release_tag}" ]]; then
+            echo "Backend compose image tag ${backend_image_tag} must match BANGI_RELEASE_TAG ${release_tag}" >&2
+            exit 1
+          fi
+
+          if [[ "${ui_image_tag}" != "${release_tag}" ]]; then
+            echo "UI compose image tag ${ui_image_tag} must match BANGI_RELEASE_TAG ${release_tag}" >&2
+            exit 1
+          fi
+
+          if git ls-remote --exit-code --tags origin "refs/tags/${release_tag}" >/dev/null 2>&1; then
+            echo "Release tag ${release_tag} already exists" >&2
+            exit 1
+          fi
+
   api-black:
     continue-on-error: true
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,94 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - infra/installer/install.sh
+      - infra/installer/templates/compose.prod.yml
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  release-tag:
+    name: Create release tag
+    runs-on: ubuntu-latest
+    outputs:
+      release_tag: ${{ steps.version.outputs.release_tag }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Read release tag
+        id: version
+        run: |
+          set -euo pipefail
+
+          release_tag="$(sed -n 's/^BANGI_RELEASE_TAG="\([^"]*\)"$/\1/p' infra/installer/install.sh)"
+
+          if [[ -z "${release_tag}" ]]; then
+            echo "BANGI_RELEASE_TAG is missing from infra/installer/install.sh" >&2
+            exit 1
+          fi
+
+          if git ls-remote --exit-code --tags origin "refs/tags/${release_tag}" >/dev/null 2>&1; then
+            echo "Release tag ${release_tag} already exists" >&2
+            exit 1
+          fi
+
+          echo "release_tag=${release_tag}" >> "${GITHUB_OUTPUT}"
+
+      - name: Create release tag
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag "${{ steps.version.outputs.release_tag }}" "${{ github.sha }}"
+          git push origin "${{ steps.version.outputs.release_tag }}"
+
+  publish-api:
+    name: Publish API image
+    needs: release-tag
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: ./apps/api
+          push: true
+          tags: ghcr.io/devalentino/bangi-backend:${{ needs.release-tag.outputs.release_tag }}
+
+  publish-web:
+    name: Publish web image
+    needs: release-tag
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./apps/web/Dockerfile
+          push: true
+          tags: ghcr.io/devalentino/bangi-ui:${{ needs.release-tag.outputs.release_tag }}

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -2,7 +2,7 @@ FROM node:20-alpine AS builder
 
 WORKDIR /app
 
-COPY package.json package-lock.json ./
+COPY apps/web/package.json apps/web/package-lock.json ./
 RUN npm ci
 
 COPY apps/web/ .
@@ -12,7 +12,7 @@ RUN npm run build
 
 FROM nginx:1.27-alpine
 
-COPY ../../infra/nginx/nginx.conf /etc/nginx/conf.d/default.conf
+COPY infra/nginx/nginx.conf /etc/nginx/conf.d/default.conf
 
 COPY --from=builder /app/index.html /usr/share/nginx/html/index.html
 COPY --from=builder /app/bin /usr/share/nginx/html/bin

--- a/docs/host-provisioning.md
+++ b/docs/host-provisioning.md
@@ -7,7 +7,7 @@ The Bangi host provisioner installs a pinned Bangi release onto a fresh Ubuntu 2
 Download the pinned installer to `/tmp` and run it with root privileges:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/devalentino/bangi/vX.Y.Z/infra/installer/install.sh -o /tmp/bangi-install.sh
+curl -fsSL https://raw.githubusercontent.com/devalentino/bangi/X.Y.Z/infra/installer/install.sh -o /tmp/bangi-install.sh
 sudo bash /tmp/bangi-install.sh
 ```
 

--- a/infra/installer/install.sh
+++ b/infra/installer/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-BANGI_RELEASE_TAG="vX.Y.Z"
+BANGI_RELEASE_TAG="0.0.1a7"
 
 INSTALLER_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 

--- a/infra/installer/templates/compose.prod.yml
+++ b/infra/installer/templates/compose.prod.yml
@@ -1,0 +1,65 @@
+services:
+  web:
+    image: ghcr.io/devalentino/bangi-ui:0.0.1a7
+    restart: always
+    ports:
+      - '127.0.0.1:8080:80'
+    networks:
+      - bangi
+
+  api:
+    image: ghcr.io/devalentino/bangi-backend:0.0.1a7
+    restart: always
+    env_file:
+      - /opt/bangi/shared/env/.env
+    environment:
+      MARIADB_HOST: mariadb
+      LANDING_PAGES_BASE_PATH: /app/landings
+      INTERNAL_PROCESS_BASE_URL: http://localhost:8000/process
+    ports:
+      - '127.0.0.1:8000:5000'
+    volumes:
+      - /opt/bangi/shared/landings:/app/landings
+      - /opt/bangi/shared/ip2location/IP2LOCATION-LITE-DB1.IPV6.BIN:/app/IP2LOCATION-LITE-DB1.IPV6.BIN:ro
+    depends_on:
+      mariadb:
+        condition: service_healthy
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://0.0.0.0:5000/api/v2/health" ]
+      interval: 120s
+      timeout: 10s
+      retries: 3
+      start_period: 120s
+    networks:
+      - bangi
+
+  mariadb:
+    image: mariadb:latest
+    restart: always
+    mem_limit: 160m
+    mem_reservation: 128m
+    env_file:
+      - /opt/bangi/shared/env/.env
+    volumes:
+      - /opt/bangi/shared/mariadb:/var/lib/mysql
+      - /opt/bangi/current/infra/mariadb/low-memory.cnf:/etc/mysql/conf.d/zzz-low-memory.cnf:ro
+    healthcheck:
+      test: [ 'CMD', 'mariadb', '-u', 'root', '-p$MARIADB_ROOT_PASSWORD', '-e', 'SHOW DATABASES' ]
+      interval: 5s
+      timeout: 5s
+      retries: 3
+    networks:
+      - bangi
+
+  landing-renderer:
+    image: php:8-apache
+    mem_limit: 64m
+    mem_reservation: 32m
+    volumes:
+      - /opt/bangi/shared/landings:/var/www/html/landings
+    networks:
+      - bangi
+
+networks:
+  bangi:
+    driver: bridge


### PR DESCRIPTION
## Summary
- Adds release automation that reads the committed Bangi release tag, creates the matching Git tag after merge, and publishes backend/UI images to GHCR.
- Adds a production compose template with literal release-pinned backend and UI image references for 0.0.1a7.
- Extends PR CI with a release-version check that validates tag bump, alpha/beta tag format, compose image consistency, and tag non-existence.
- Fixes the web Dockerfile paths so CI can build the web image from the monorepo root.

## Scope
- Included: KAN-27 release workflow, PR release validation, production compose template, release tag bump to 0.0.1a7, web image build path fixes, and install docs tag placeholder update.
- Not included: installer runtime compose startup behavior, installer tests, package/app version validation, domain/TLS provisioning, or release asset fetching implementation.

## Risks
- Medium: release automation depends on GitHub Actions permissions for contents/package writes and on release PRs updating both install.sh and compose.prod.yml consistently; PR CI now enforces the consistency before merge.

## Links
- Jira: https://bangitech.atlassian.net/browse/KAN-27
- Spec: _bmad-output/planning-artifacts/epics.md Story 1.4; _bmad-output/planning-artifacts/bangi-host-provisioner-tech-spec.md
