### PR TITLE
KAN-26: feat: create provisioner host directory layout

### DIFF
--- a/infra/installer/lib/common.sh
+++ b/infra/installer/lib/common.sh
@@ -20,7 +20,75 @@ bangi_verify_inputs() {
 }
 
 bangi_detect_existing_state() {
-    bangi_log "Existing host state detection phase pending implementation"
+    bangi_log "Checking existing Bangi-managed host state"
+
+    local path=""
+    local current_target=""
+    local allowed_child=""
+    local child=""
+    local child_name=""
+    local is_allowed=""
+    local expected_dirs=(
+        "${BANGI_ROOT_DIR}"
+        "${BANGI_RELEASE_DIR}"
+        "${BANGI_SHARED_DIR}"
+        "${BANGI_SHARED_ENV_DIR}"
+        "${BANGI_SHARED_MARIADB_DIR}"
+        "${BANGI_SHARED_LANDINGS_DIR}"
+        "${BANGI_SHARED_IP2LOCATION_DIR}"
+        "${BANGI_ROOT_DIR}/ops"
+        "${BANGI_OPS_BIN_DIR}"
+        "${BANGI_ETC_DIR}"
+        "${BANGI_NGINX_DIR}"
+        "${BANGI_NGINX_AVAILABLE_DIR}"
+        "${BANGI_NGINX_ENABLED_DIR}"
+        "${BANGI_LOG_DIR}"
+    )
+    local allowed_root_children=(
+        "${BANGI_RELEASE_TAG}"
+        "current"
+        "shared"
+        "ops"
+    )
+
+    for path in "${expected_dirs[@]}"; do
+        if [[ -e "${path}" && ! -d "${path}" ]]; then
+            bangi_fatal "Unsupported existing Bangi host state at ${path}: expected a directory. Install on a clean VPS."
+        fi
+    done
+
+    if [[ -e "${BANGI_CURRENT_LINK}" || -L "${BANGI_CURRENT_LINK}" ]]; then
+        if [[ ! -L "${BANGI_CURRENT_LINK}" ]]; then
+            bangi_fatal "Unsupported existing Bangi host state at ${BANGI_CURRENT_LINK}: expected a symlink. Install on a clean VPS."
+        fi
+
+        current_target="$(readlink "${BANGI_CURRENT_LINK}")" \
+            || bangi_fatal "Unsupported existing Bangi host state at ${BANGI_CURRENT_LINK}: unreadable symlink. Install on a clean VPS."
+
+        if [[ "${current_target}" != "${BANGI_RELEASE_DIR}" ]]; then
+            bangi_fatal "Unsupported existing Bangi host state at ${BANGI_CURRENT_LINK}: expected ${BANGI_RELEASE_DIR}. Install on a clean VPS."
+        fi
+    fi
+
+    if [[ -d "${BANGI_ROOT_DIR}" ]]; then
+        for child in "${BANGI_ROOT_DIR}"/*; do
+            [[ -e "${child}" || -L "${child}" ]] || continue
+
+            child_name="$(basename "${child}")"
+            is_allowed="false"
+
+            for allowed_child in "${allowed_root_children[@]}"; do
+                if [[ "${child_name}" == "${allowed_child}" ]]; then
+                    is_allowed="true"
+                    break
+                fi
+            done
+
+            if [[ "${is_allowed}" != "true" ]]; then
+                bangi_fatal "Unsupported existing Bangi host state at ${child}. Install on a clean VPS."
+            fi
+        done
+    fi
 }
 
 bangi_print_summary() {

--- a/infra/installer/lib/paths.sh
+++ b/infra/installer/lib/paths.sh
@@ -10,12 +10,32 @@ BANGI_SHARED_LANDINGS_DIR="${BANGI_SHARED_DIR}/landings"
 BANGI_SHARED_IP2LOCATION_DIR="${BANGI_SHARED_DIR}/ip2location"
 BANGI_OPS_BIN_DIR="${BANGI_ROOT_DIR}/ops/bin"
 BANGI_ETC_DIR="/etc/bangi"
+BANGI_NGINX_DIR="/etc/nginx/bangi"
 BANGI_NGINX_AVAILABLE_DIR="/etc/nginx/bangi/sites-available"
 BANGI_NGINX_ENABLED_DIR="/etc/nginx/bangi/sites-enabled"
 BANGI_LOG_DIR="/var/log/bangi"
 
 bangi_create_paths() {
-    bangi_log "Path creation phase pending implementation"
+    local path=""
+    local managed_dirs=(
+        "${BANGI_RELEASE_DIR}"
+        "${BANGI_SHARED_ENV_DIR}"
+        "${BANGI_SHARED_MARIADB_DIR}"
+        "${BANGI_SHARED_LANDINGS_DIR}"
+        "${BANGI_SHARED_IP2LOCATION_DIR}"
+        "${BANGI_OPS_BIN_DIR}"
+        "${BANGI_ETC_DIR}"
+        "${BANGI_NGINX_AVAILABLE_DIR}"
+        "${BANGI_NGINX_ENABLED_DIR}"
+        "${BANGI_LOG_DIR}"
+    )
+
+    bangi_log "Creating Bangi host directory layout"
+
+    for path in "${managed_dirs[@]}"; do
+        install -d -m 0755 -o root -g root "${path}" \
+            || bangi_fatal "Path creation failed for ${path}"
+    done
 }
 
 bangi_activate_release() {


### PR DESCRIPTION
## Summary
- Implements KAN-26 host layout creation for the Bangi installer.
- Adds fail-fast validation for unsupported Bangi-related host state before package installation and path mutation.
- Keeps same-release reruns idempotent by reusing the fixed managed directory set.

## Scope
- Included: `/opt/bangi/<tag>`, shared runtime directories, ops bin, `/etc/bangi`, Bangi-managed Nginx workspace, and `/var/log/bangi` creation.
- Included: validation for malformed managed paths, invalid `/opt/bangi/current`, and unexpected `/opt/bangi` children.
- Not included: installer bootstrap module downloads, deployment asset fetching, environment generation, compose startup, Nginx config installation, cron, ops user setup, or health verification.

## Risks
- Low implementation risk; changes are limited to installer path/state modules.
- Manual host verification is still required because installer stories are not covered by automated local tests per Jira implementation guidance.

## Links
- Jira: https://bangitech.atlassian.net/browse/KAN-26
- Spec: https://bangitech.atlassian.net/wiki/spaces/SD/pages/8093698
