### PR TITLE
KAN-29: feat: installer materializes runtime and ops environment files

### DIFF
--- a/.agents/skills/github-pr-create/references/workflow.md
+++ b/.agents/skills/github-pr-create/references/workflow.md
@@ -44,6 +44,7 @@ This workflow prepares and opens a GitHub pull request from the current branch b
    - Ensure the PR title matches either `<jira_ticket>: <prefix>: <pr_title>` or `<prefix>: <pr_title>`.
    - When `jira_ticket` is present, ensure it is a concrete ticket ID such as `KAN-11`, not `TBD`.
    - Ensure `prefix` is exactly one of: `feat`, `fix`, `migration`, `refactor`, `chore`, `test`, `docs`, `perf`.
+   - Ensure `pr_title` names the affected area when the task wording is generic, so it is clear without Jira or branch context.
    - If essential context is missing and cannot be inferred safely, stop and ask the user for the missing item instead of opening a weak PR.
 
 5. Create the PR.
@@ -60,6 +61,7 @@ This workflow prepares and opens a GitHub pull request from the current branch b
      - `docs`: Documentation-only changes.
      - `perf`: A code change that improves performance.
    - Write `pr_title` as a concise reviewer-oriented summary of the actual change, without repeating the ticket or prefix.
+   - Derive area wording from changed paths when useful, e.g. `infra/installer/**` -> `provisioner installer fetches pinned deployment assets`.
    - If the workflow cannot determine a valid `prefix` confidently, stop and ask the user instead of guessing.
    - Open the PR with `gh pr create`.
    - Always pass the resolved default branch explicitly via `--base`.

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -9,7 +9,7 @@ This application now lives inside the Bangi monorepo at `apps/web`.
 - Entry point: `index.html` + `index.js`
 - Source code: `src/`
 - Production bundle output: `bin/main.js`
-- API base URL is configurable at runtime via `app-config.js`
+- API base URL defaults to `/api/v2` and can be overridden at runtime via `app-config.js`
 
 ## Local Development
 
@@ -46,7 +46,7 @@ npm run start
 
 ### Runtime API URL (post-deploy configurable)
 
-The app reads:
+The app uses `/api/v2` by default. For custom deployments, override it with:
 
 - `window.APP_CONFIG.BACKEND_API_BASE_URL` from `app-config.js`
 
@@ -64,7 +64,7 @@ The repo includes a multi-stage Docker build:
 
 - Build stage: Node + esbuild
 - Runtime stage: Nginx serving static assets
-- Container startup script generates `/usr/share/nginx/html/app-config.js` from `BACKEND_API_BASE_URL`
+- The pre-built image works without `BACKEND_API_BASE_URL` when the host routes `/api/v2` to the backend.
 
 ### Build Image
 
@@ -98,5 +98,5 @@ docker push ghcr.io/devalentino/bangi-web:$(git describe --tags --exact-match)
 
 ## Deploy Notes
 
-- `app-config.js` is runtime-generated in Docker, so you can change API URL per environment without rebuilding image.
+- Override `app-config.js` when a deployment needs a non-default API URL.
 - For non-Docker deployments, edit `app-config.js` on the server and reload the page.

--- a/apps/web/src/config.js
+++ b/apps/web/src/config.js
@@ -5,7 +5,7 @@ if (typeof window !== "undefined" && window.APP_CONFIG) {
 }
 
 var backendApiBaseUrl =
-  runtimeConfig.BACKEND_API_BASE_URL || process.env.BACKEND_API_BASE_URL || "";
+  runtimeConfig.BACKEND_API_BASE_URL || process.env.BACKEND_API_BASE_URL || "/api/v2";
 
 module.exports = {
   backendApiBaseUrl: backendApiBaseUrl,

--- a/docs/host-provisioning.md
+++ b/docs/host-provisioning.md
@@ -11,6 +11,10 @@ curl -fsSL https://raw.githubusercontent.com/devalentino/bangi/X.Y.Z/infra/insta
 sudo bash /tmp/bangi-install.sh
 ```
 
+During installation, the wizard asks for the optional IP2Location download token. Leave it blank to skip automated refresh credentials. If a token is entered, the installer validates it against IP2Location and asks again when validation fails.
+
+The installer writes the token to `/etc/bangi/ops.env`, not to the application runtime `.env`. On rerun, an existing value in `/etc/bangi/ops.env` is preserved.
+
 The installer must run as root and validates Ubuntu 24.04 LTS before any package installation phase starts.
 
 ## Manual Verification

--- a/infra/installer/lib/env.sh
+++ b/infra/installer/lib/env.sh
@@ -1,5 +1,209 @@
 #!/usr/bin/env bash
 
+BANGI_RUNTIME_ENV_FILE="${BANGI_SHARED_ENV_DIR}/.env"
+BANGI_OPS_ENV_FILE="${BANGI_ETC_DIR}/ops.env"
+BANGI_IP2LOCATION_DOWNLOAD_FILE="DB1LITEBINIPV6"
+
+bangi_env_secret() {
+    od -An -N32 -tx1 /dev/urandom | tr -d ' \n'
+}
+
+bangi_env_load_file() {
+    local file_path="$1"
+    local -n target_values="$2"
+    local line=""
+    local key=""
+    local value=""
+
+    [[ -f "${file_path}" ]] || return 0
+
+    while IFS= read -r line || [[ -n "${line}" ]]; do
+        [[ -n "${line}" && "${line}" != \#* && "${line}" == *=* ]] || continue
+
+        key="${line%%=*}"
+        value="${line#*=}"
+        key="${key#export }"
+
+        [[ "${key}" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
+        target_values["${key}"]="${value}"
+    done <"${file_path}"
+}
+
+bangi_env_set_if_missing() {
+    local -n target_values="$1"
+    local key="$2"
+    local value="$3"
+
+    if [[ -z "${target_values[${key}]+x}" || -z "${target_values[${key}]}" ]]; then
+        target_values["${key}"]="${value}"
+    fi
+}
+
+bangi_env_write_file() {
+    local file_path="$1"
+    local mode="$2"
+    shift 2
+
+    local temporary_path="${file_path}.tmp"
+    local previous_umask=""
+    local key=""
+
+    previous_umask="$(umask)"
+    umask 077
+    if ! : >"${temporary_path}"; then
+        umask "${previous_umask}"
+        bangi_fatal "Cannot create temporary environment file: ${temporary_path}"
+    fi
+    umask "${previous_umask}"
+
+    for key in "$@"; do
+        printf '%s=%s\n' "${key}" "${BANGI_ENV_VALUES[${key}]}" >>"${temporary_path}" \
+            || bangi_fatal "Cannot write environment value ${key} to ${temporary_path}"
+    done
+
+    chown root:root "${temporary_path}" \
+        || bangi_fatal "Cannot set ownership on environment file ${file_path}"
+    chmod "${mode}" "${temporary_path}" \
+        || bangi_fatal "Cannot set permissions on environment file ${file_path}"
+    mv -f "${temporary_path}" "${file_path}" \
+        || bangi_fatal "Cannot install environment file ${file_path}"
+}
+
+bangi_env_validate_required() {
+    local key=""
+
+    for key in "$@"; do
+        if [[ -z "${BANGI_ENV_VALUES[${key}]+x}" || -z "${BANGI_ENV_VALUES[${key}]}" ]]; then
+            bangi_fatal "Required runtime environment value ${key} is blank"
+        fi
+    done
+}
+
+bangi_env_prompt_secret() {
+    local prompt="$1"
+    local value=""
+
+    if [[ ! -t 0 ]]; then
+        printf '\n'
+        return 0
+    fi
+
+    printf '%s' "${prompt}" >&2
+    IFS= read -r -s value
+    printf '\n' >&2
+    printf '%s\n' "${value}"
+}
+
+bangi_env_validate_ip2location_token() {
+    local token="$1"
+    local temporary_path=""
+    local zip_signature=""
+    local download_url="https://www.ip2location.com/download?token=${token}&file=${BANGI_IP2LOCATION_DOWNLOAD_FILE}"
+
+    [[ -n "${token}" ]] || return 1
+
+    temporary_path="$(mktemp)" \
+        || bangi_fatal "Cannot create temporary file for IP2Location token validation"
+
+    if ! curl -fsSL --max-time 45 "${download_url}" -o "${temporary_path}"; then
+        rm -f "${temporary_path}"
+        return 1
+    fi
+
+    zip_signature="$(head -c 4 "${temporary_path}" | od -An -tx1 | tr -d ' \n')"
+    rm -f "${temporary_path}"
+
+    [[ "${zip_signature}" == "504b0304" || "${zip_signature}" == "504b0506" || "${zip_signature}" == "504b0708" ]]
+}
+
+bangi_env_read_ip2location_token() {
+    local token="${IP2LOCATION_DOWNLOAD_TOKEN:-}"
+
+    while true; do
+        if [[ -z "${token}" ]]; then
+            bangi_log "IP2Location download token is optional; leave blank to skip automated refresh credentials." >&2
+            token="$(bangi_env_prompt_secret "IP2Location download token: ")"
+        fi
+
+        if [[ -z "${token}" ]]; then
+            printf '\n'
+            return 0
+        fi
+
+        bangi_log "Validating IP2Location download token" >&2
+        if bangi_env_validate_ip2location_token "${token}"; then
+            printf '%s\n' "${token}"
+            return 0
+        fi
+
+        if [[ ! -t 0 ]]; then
+            bangi_fatal "IP2Location download token validation failed"
+        fi
+
+        bangi_log "IP2Location download token validation failed. Enter another token, or leave blank to skip." >&2
+        token=""
+    done
+}
+
+bangi_write_runtime_environment() {
+    local runtime_keys=(
+        MARIADB_ROOT_PASSWORD
+        MARIADB_USER
+        MARIADB_PASSWORD
+        MARIADB_HOST
+        MARIADB_PORT
+        MARIADB_DATABASE
+        BASIC_AUTHENTICATION_USERNAME
+        BASIC_AUTHENTICATION_PASSWORD
+        LANDING_PAGES_BASE_PATH
+        IP2LOCATION_DB_PATH
+        LANDING_PAGE_RENDERER_BASE_URL
+    )
+
+    declare -gA BANGI_ENV_VALUES=()
+    bangi_env_load_file "${BANGI_RUNTIME_ENV_FILE}" BANGI_ENV_VALUES
+
+    bangi_env_set_if_missing BANGI_ENV_VALUES MARIADB_ROOT_PASSWORD "$(bangi_env_secret)"
+    bangi_env_set_if_missing BANGI_ENV_VALUES MARIADB_USER "bangi"
+    bangi_env_set_if_missing BANGI_ENV_VALUES MARIADB_PASSWORD "$(bangi_env_secret)"
+    bangi_env_set_if_missing BANGI_ENV_VALUES MARIADB_HOST "mariadb"
+    bangi_env_set_if_missing BANGI_ENV_VALUES MARIADB_PORT "3306"
+    bangi_env_set_if_missing BANGI_ENV_VALUES MARIADB_DATABASE "bangi"
+    bangi_env_set_if_missing BANGI_ENV_VALUES BASIC_AUTHENTICATION_USERNAME "admin"
+    bangi_env_set_if_missing BANGI_ENV_VALUES BASIC_AUTHENTICATION_PASSWORD "$(bangi_env_secret)"
+    bangi_env_set_if_missing BANGI_ENV_VALUES LANDING_PAGES_BASE_PATH "${BANGI_SHARED_LANDINGS_DIR}"
+    bangi_env_set_if_missing BANGI_ENV_VALUES IP2LOCATION_DB_PATH "${BANGI_SHARED_IP2LOCATION_DIR}/IP2LOCATION-LITE-DB1.IPV6.BIN"
+    bangi_env_set_if_missing BANGI_ENV_VALUES LANDING_PAGE_RENDERER_BASE_URL "http://landing-renderer"
+
+    bangi_env_validate_required "${runtime_keys[@]}"
+    bangi_env_write_file "${BANGI_RUNTIME_ENV_FILE}" "0600" "${runtime_keys[@]}"
+}
+
+bangi_write_ops_environment() {
+    local ops_keys=(
+        IP2LOCATION_DOWNLOAD_TOKEN
+    )
+    local ip2location_download_token=""
+
+    declare -gA BANGI_ENV_VALUES=()
+    bangi_env_load_file "${BANGI_OPS_ENV_FILE}" BANGI_ENV_VALUES
+
+    if [[ -z "${BANGI_ENV_VALUES[IP2LOCATION_DOWNLOAD_TOKEN]+x}" || -z "${BANGI_ENV_VALUES[IP2LOCATION_DOWNLOAD_TOKEN]}" ]]; then
+        ip2location_download_token="$(bangi_env_read_ip2location_token)"
+        bangi_env_set_if_missing BANGI_ENV_VALUES IP2LOCATION_DOWNLOAD_TOKEN "${ip2location_download_token}"
+    fi
+
+    bangi_env_write_file "${BANGI_OPS_ENV_FILE}" "0600" "${ops_keys[@]}"
+}
+
 bangi_write_environment() {
-    bangi_log "Environment file phase pending implementation"
+    bangi_log "Materializing Bangi runtime and operational environment files"
+
+    install -d -m 0755 -o root -g root "${BANGI_SHARED_ENV_DIR}" \
+        || bangi_fatal "Cannot create runtime environment directory: ${BANGI_SHARED_ENV_DIR}"
+    install -d -m 0755 -o root -g root "${BANGI_ETC_DIR}" \
+        || bangi_fatal "Cannot create operational environment directory: ${BANGI_ETC_DIR}"
+
+    bangi_write_runtime_environment
+    bangi_write_ops_environment
 }


### PR DESCRIPTION
## Summary
- Materializes Bangi runtime `.env` and operational `ops.env` files during host installation.
- Preserves existing environment values on rerun while generating missing credentials and defaults.
- Adds optional IP2Location token prompting and validation, and defaults the web API base URL to `/api/v2`.

## Scope
- Included: installer environment file generation, IP2Location ops token handling, web runtime API default, and related provisioning/docs updates.
- Not included: package installation phases, deployment service wiring, database migrations, or UI behavior changes beyond API base URL resolution.

## Risks
- Low to moderate: installer reruns now rewrite managed env files with `0600` permissions and preserve known keys, so deployments with unmanaged extra keys in those files should verify they are not relying on unsupported values.

## Links
- Jira: KAN-29
- Spec: TBD
