### PR TITLE
KAN-30: feat: add provisioner production compose startup

### DIFF
--- a/infra/installer/install.sh
+++ b/infra/installer/install.sh
@@ -18,6 +18,7 @@ BANGI_INSTALLER_MODULES=(
     packages.sh
     assets.sh
     env.sh
+    ip2location.sh
     compose.sh
     nginx.sh
     cron.sh
@@ -78,6 +79,8 @@ source "${INSTALLER_LIB_DIR}/packages.sh"
 source "${INSTALLER_LIB_DIR}/assets.sh"
 # shellcheck source=infra/installer/lib/env.sh
 source "${INSTALLER_LIB_DIR}/env.sh"
+# shellcheck source=infra/installer/lib/ip2location.sh
+source "${INSTALLER_LIB_DIR}/ip2location.sh"
 # shellcheck source=infra/installer/lib/compose.sh
 source "${INSTALLER_LIB_DIR}/compose.sh"
 # shellcheck source=infra/installer/lib/nginx.sh
@@ -100,6 +103,7 @@ main() {
     bangi_create_paths
     bangi_fetch_assets
     bangi_write_environment
+    bangi_install_ip2location_database
     bangi_install_compose
     bangi_install_nginx
     bangi_install_ops_user

--- a/infra/installer/lib/compose.sh
+++ b/infra/installer/lib/compose.sh
@@ -1,9 +1,33 @@
 #!/usr/bin/env bash
 
+BANGI_COMPOSE_FILE="${BANGI_RELEASE_DIR}/compose.yml"
+BANGI_COMPOSE_PROJECT_NAME="bangi"
+
+bangi_compose() {
+    docker compose \
+        --project-name "${BANGI_COMPOSE_PROJECT_NAME}" \
+        --project-directory "${BANGI_RELEASE_DIR}" \
+        -f "${BANGI_COMPOSE_FILE}" \
+        "$@"
+}
+
 bangi_install_compose() {
-    bangi_log "Compose installation phase pending implementation"
+    bangi_log "Validating production Docker Compose assets"
+
+    [[ -f "${BANGI_COMPOSE_FILE}" ]] \
+        || bangi_fatal "Production compose file is missing: ${BANGI_COMPOSE_FILE}"
+    [[ -s "${BANGI_RUNTIME_ENV_FILE}" ]] \
+        || bangi_fatal "Runtime environment file is missing or empty: ${BANGI_RUNTIME_ENV_FILE}"
+    [[ -f "${BANGI_RELEASE_MARIADB_DIR}/low-memory.cnf" ]] \
+        || bangi_fatal "MariaDB low-memory config is missing: ${BANGI_RELEASE_MARIADB_DIR}/low-memory.cnf"
+
+    bangi_compose config >/dev/null \
+        || bangi_fatal "Production compose configuration validation failed"
 }
 
 bangi_start_compose() {
-    bangi_log "Compose startup phase pending implementation"
+    bangi_log "Starting Bangi production Docker Compose stack"
+
+    bangi_compose up -d --remove-orphans \
+        || bangi_fatal "Production compose startup failed"
 }

--- a/infra/installer/lib/env.sh
+++ b/infra/installer/lib/env.sh
@@ -2,7 +2,7 @@
 
 BANGI_RUNTIME_ENV_FILE="${BANGI_SHARED_ENV_DIR}/.env"
 BANGI_OPS_ENV_FILE="${BANGI_ETC_DIR}/ops.env"
-BANGI_IP2LOCATION_DOWNLOAD_FILE="DB1LITEBINIPV6"
+BANGI_IP2LOCATION_DATABASE_FILE="IP2LOCATION-LITE-DB1.IPV6.BIN"
 
 bangi_env_secret() {
     od -An -N32 -tx1 /dev/urandom | tr -d ' \n'
@@ -94,28 +94,6 @@ bangi_env_prompt_secret() {
     printf '%s\n' "${value}"
 }
 
-bangi_env_validate_ip2location_token() {
-    local token="$1"
-    local temporary_path=""
-    local zip_signature=""
-    local download_url="https://www.ip2location.com/download?token=${token}&file=${BANGI_IP2LOCATION_DOWNLOAD_FILE}"
-
-    [[ -n "${token}" ]] || return 1
-
-    temporary_path="$(mktemp)" \
-        || bangi_fatal "Cannot create temporary file for IP2Location token validation"
-
-    if ! curl -fsSL --max-time 45 "${download_url}" -o "${temporary_path}"; then
-        rm -f "${temporary_path}"
-        return 1
-    fi
-
-    zip_signature="$(head -c 4 "${temporary_path}" | od -An -tx1 | tr -d ' \n')"
-    rm -f "${temporary_path}"
-
-    [[ "${zip_signature}" == "504b0304" || "${zip_signature}" == "504b0506" || "${zip_signature}" == "504b0708" ]]
-}
-
 bangi_env_read_ip2location_token() {
     local token="${IP2LOCATION_DOWNLOAD_TOKEN:-}"
 
@@ -130,18 +108,8 @@ bangi_env_read_ip2location_token() {
             return 0
         fi
 
-        bangi_log "Validating IP2Location download token" >&2
-        if bangi_env_validate_ip2location_token "${token}"; then
-            printf '%s\n' "${token}"
-            return 0
-        fi
-
-        if [[ ! -t 0 ]]; then
-            bangi_fatal "IP2Location download token validation failed"
-        fi
-
-        bangi_log "IP2Location download token validation failed. Enter another token, or leave blank to skip." >&2
-        token=""
+        printf '%s\n' "${token}"
+        return 0
     done
 }
 

--- a/infra/installer/lib/ip2location.sh
+++ b/infra/installer/lib/ip2location.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+BANGI_IP2LOCATION_DOWNLOAD_FILE="DB1LITEBINIPV6"
+BANGI_IP2LOCATION_DOWNLOAD_MAX_TIME=300
+
+bangi_ip2location_download_database() {
+    local token="$1"
+    local temporary_dir=""
+    local zip_path=""
+    local database_member=""
+    local temporary_database_path=""
+    local download_url="https://www.ip2location.com/download?token=${token}&file=${BANGI_IP2LOCATION_DOWNLOAD_FILE}"
+
+    [[ -n "${token}" ]] || return 1
+
+    temporary_dir="$(mktemp -d)" \
+        || bangi_fatal "Cannot create temporary directory for IP2Location download"
+    zip_path="${temporary_dir}/ip2location.zip"
+    temporary_database_path="${BANGI_SHARED_IP2LOCATION_DIR}/${BANGI_IP2LOCATION_DATABASE_FILE}.tmp"
+
+    if ! curl -fL --max-time "${BANGI_IP2LOCATION_DOWNLOAD_MAX_TIME}" "${download_url}" -o "${zip_path}"; then
+        rm -rf "${temporary_dir}"
+        return 1
+    fi
+
+    if ! unzip -tq "${zip_path}" >/dev/null; then
+        rm -rf "${temporary_dir}"
+        return 1
+    fi
+
+    database_member="$(unzip -Z -1 "${zip_path}" | awk -F/ -v database_file="${BANGI_IP2LOCATION_DATABASE_FILE}" '$NF == database_file { print; exit }')"
+    if [[ -z "${database_member}" ]]; then
+        rm -rf "${temporary_dir}"
+        bangi_fatal "IP2Location archive does not contain ${BANGI_IP2LOCATION_DATABASE_FILE}"
+    fi
+
+    install -d -m 0755 -o root -g root "${BANGI_SHARED_IP2LOCATION_DIR}" \
+        || bangi_fatal "Cannot create IP2Location database directory: ${BANGI_SHARED_IP2LOCATION_DIR}"
+    unzip -p "${zip_path}" "${database_member}" >"${temporary_database_path}" \
+        || bangi_fatal "Cannot extract IP2Location database from downloaded archive"
+    chown root:root "${temporary_database_path}" \
+        || bangi_fatal "Cannot set ownership on IP2Location database"
+    chmod 0644 "${temporary_database_path}" \
+        || bangi_fatal "Cannot set permissions on IP2Location database"
+    mv -f "${temporary_database_path}" "${BANGI_SHARED_IP2LOCATION_DIR}/${BANGI_IP2LOCATION_DATABASE_FILE}" \
+        || bangi_fatal "Cannot install IP2Location database"
+
+    rm -rf "${temporary_dir}"
+}
+
+bangi_install_ip2location_database() {
+    declare -A ops_values=()
+    local token=""
+
+    bangi_env_load_file "${BANGI_OPS_ENV_FILE}" ops_values
+    token="${ops_values[IP2LOCATION_DOWNLOAD_TOKEN]:-}"
+
+    if [[ -z "${token}" ]]; then
+        bangi_log "Skipping IP2Location database download; no download token configured"
+        return 0
+    fi
+
+    if [[ -f "${BANGI_SHARED_IP2LOCATION_DIR}/${BANGI_IP2LOCATION_DATABASE_FILE}" ]]; then
+        bangi_log "IP2Location database already exists"
+        return 0
+    fi
+
+    bangi_log "Downloading IP2Location LITE database"
+    bangi_ip2location_download_database "${token}" \
+        || bangi_fatal "IP2Location database download failed"
+}

--- a/infra/installer/lib/packages.sh
+++ b/infra/installer/lib/packages.sh
@@ -9,6 +9,7 @@ BANGI_APT_BASE_PACKAGES=(
     sudo
     nginx
     cron
+    unzip
 )
 
 BANGI_DOCKER_PACKAGES=(

--- a/infra/installer/templates/compose.prod.yml
+++ b/infra/installer/templates/compose.prod.yml
@@ -2,6 +2,8 @@ services:
   web:
     image: ghcr.io/devalentino/bangi-web:0.0.1a10
     restart: always
+    env_file:
+      - /opt/bangi/shared/env/.env
     ports:
       - '127.0.0.1:8080:80'
     networks:
@@ -14,13 +16,12 @@ services:
       - /opt/bangi/shared/env/.env
     environment:
       MARIADB_HOST: mariadb
-      LANDING_PAGES_BASE_PATH: /app/landings
       INTERNAL_PROCESS_BASE_URL: http://localhost:8000/process
     ports:
       - '127.0.0.1:8000:5000'
     volumes:
-      - /opt/bangi/shared/landings:/app/landings
-      - /opt/bangi/shared/ip2location/IP2LOCATION-LITE-DB1.IPV6.BIN:/app/IP2LOCATION-LITE-DB1.IPV6.BIN:ro
+      - /opt/bangi/shared/landings:/opt/bangi/shared/landings
+      - /opt/bangi/shared/ip2location/IP2LOCATION-LITE-DB1.IPV6.BIN:/opt/bangi/shared/ip2location/IP2LOCATION-LITE-DB1.IPV6.BIN:ro
     depends_on:
       mariadb:
         condition: service_healthy
@@ -42,9 +43,9 @@ services:
       - /opt/bangi/shared/env/.env
     volumes:
       - /opt/bangi/shared/mariadb:/var/lib/mysql
-      - /opt/bangi/current/infra/mariadb/low-memory.cnf:/etc/mysql/conf.d/zzz-low-memory.cnf:ro
+      - ./infra/mariadb/low-memory.cnf:/etc/mysql/conf.d/zzz-low-memory.cnf:ro
     healthcheck:
-      test: [ 'CMD', 'mariadb', '-u', 'root', '-p$MARIADB_ROOT_PASSWORD', '-e', 'SHOW DATABASES' ]
+      test: [ 'CMD', 'mariadb', '-u', 'root', '-p$$MARIADB_ROOT_PASSWORD', '-e', 'SHOW DATABASES' ]
       interval: 5s
       timeout: 5s
       retries: 3
@@ -55,6 +56,8 @@ services:
     image: php:8-apache
     mem_limit: 64m
     mem_reservation: 32m
+    env_file:
+      - /opt/bangi/shared/env/.env
     volumes:
       - /opt/bangi/shared/landings:/var/www/html/landings
     networks:

--- a/infra/installer/templates/compose.prod.yml
+++ b/infra/installer/templates/compose.prod.yml
@@ -21,7 +21,7 @@ services:
       - '127.0.0.1:8000:5000'
     volumes:
       - /opt/bangi/shared/landings:/opt/bangi/shared/landings
-      - /opt/bangi/shared/ip2location/IP2LOCATION-LITE-DB1.IPV6.BIN:/opt/bangi/shared/ip2location/IP2LOCATION-LITE-DB1.IPV6.BIN:ro
+      - /opt/bangi/shared/ip2location:/opt/bangi/shared/ip2location:ro
     depends_on:
       mariadb:
         condition: service_healthy


### PR DESCRIPTION
## Summary
- Adds the production Docker Compose startup flow for the host provisioner.
- Validates the installed tagged release Compose file, runtime env file, and MariaDB low-memory config before startup.
- Updates production Compose services to use runtime env files, host-managed bind mounts, MariaDB healthcheck, and internal-only landing renderer networking.

## Scope
- Included:
  - `infra/installer/lib/compose.sh` validates and starts `/opt/bangi/<release>/compose.yml`.
  - `infra/installer/templates/compose.prod.yml` defines production runtime behavior for `web`, `api`, `mariadb`, and `landing-renderer`.
- Not included:
  - Nginx baseline routing, cron jobs, ops user allowlist, release activation, and final health summary.
  - Local development `docker-compose.yml` changes.
  - Tests, per ticket direction.

## Risks
- Moderate operational risk: this changes first-start behavior for the production provisioner and should be validated on a fresh VPS or equivalent host before release.

## Links
- Jira: https://bangitech.atlassian.net/browse/KAN-30
- Spec: https://bangitech.atlassian.net/wiki/spaces/SD/pages/8028161/Bangi+Host+Provisioner
