### PR TITLE
KAN-31: feat: installer configures host Nginx baseline

### DIFF
--- a/infra/installer/lib/assets.sh
+++ b/infra/installer/lib/assets.sh
@@ -6,6 +6,7 @@ BANGI_RAW_BASE_URL="https://raw.githubusercontent.com/${BANGI_GITHUB_OWNER}/${BA
 BANGI_DEPLOYMENT_ASSETS=(
     "infra/installer/templates/compose.prod.yml|${BANGI_RELEASE_DIR}/compose.yml|0644"
     "infra/installer/templates/compose.prod.yml|${BANGI_RELEASE_TEMPLATE_DIR}/compose.prod.yml|0644"
+    "infra/installer/templates/nginx.default.conf|${BANGI_RELEASE_TEMPLATE_DIR}/nginx.default.conf|0644"
     "infra/mariadb/low-memory.cnf|${BANGI_RELEASE_MARIADB_DIR}/low-memory.cnf|0644"
     "scripts/ingest_disk_utilization.sh|${BANGI_RELEASE_SCRIPTS_DIR}/ingest_disk_utilization.sh|0755"
 )

--- a/infra/installer/lib/nginx.sh
+++ b/infra/installer/lib/nginx.sh
@@ -1,5 +1,80 @@
 #!/usr/bin/env bash
 
+BANGI_NGINX_INCLUDE_FILE="/etc/nginx/conf.d/bangi.conf"
+BANGI_NGINX_DEFAULT_SITE_NAME="bangi-default.conf"
+BANGI_NGINX_DEFAULT_SITE_AVAILABLE="${BANGI_NGINX_AVAILABLE_DIR}/${BANGI_NGINX_DEFAULT_SITE_NAME}"
+BANGI_NGINX_DEFAULT_SITE_ENABLED="${BANGI_NGINX_ENABLED_DIR}/${BANGI_NGINX_DEFAULT_SITE_NAME}"
+BANGI_NGINX_DEFAULT_TEMPLATE="${BANGI_RELEASE_TEMPLATE_DIR}/nginx.default.conf"
+
+bangi_write_nginx_include() {
+    local temporary_path="${BANGI_NGINX_INCLUDE_FILE}.tmp"
+
+    install -d -m 0755 -o root -g root "$(dirname "${BANGI_NGINX_INCLUDE_FILE}")" \
+        || bangi_fatal "Cannot create Nginx include directory: $(dirname "${BANGI_NGINX_INCLUDE_FILE}")"
+
+    cat >"${temporary_path}" <<EOF \
+        || bangi_fatal "Cannot write Nginx include configuration: ${BANGI_NGINX_INCLUDE_FILE}"
+# Managed by Bangi installer. Local edits may be overwritten.
+include ${BANGI_NGINX_ENABLED_DIR}/*;
+EOF
+
+    chown root:root "${temporary_path}" \
+        || bangi_fatal "Cannot set ownership on Nginx include configuration: ${BANGI_NGINX_INCLUDE_FILE}"
+    chmod 0644 "${temporary_path}" \
+        || bangi_fatal "Cannot set permissions on Nginx include configuration: ${BANGI_NGINX_INCLUDE_FILE}"
+    mv -f "${temporary_path}" "${BANGI_NGINX_INCLUDE_FILE}" \
+        || bangi_fatal "Cannot install Nginx include configuration: ${BANGI_NGINX_INCLUDE_FILE}"
+}
+
+bangi_install_default_nginx_site() {
+    [[ -f "${BANGI_NGINX_DEFAULT_TEMPLATE}" ]] \
+        || bangi_fatal "Default Nginx site template is missing: ${BANGI_NGINX_DEFAULT_TEMPLATE}"
+
+    install -m 0644 -o root -g root "${BANGI_NGINX_DEFAULT_TEMPLATE}" "${BANGI_NGINX_DEFAULT_SITE_AVAILABLE}" \
+        || bangi_fatal "Cannot install default Bangi Nginx site: ${BANGI_NGINX_DEFAULT_SITE_AVAILABLE}"
+
+    ln -sfn "${BANGI_NGINX_DEFAULT_SITE_AVAILABLE}" "${BANGI_NGINX_DEFAULT_SITE_ENABLED}" \
+        || bangi_fatal "Cannot enable default Bangi Nginx site: ${BANGI_NGINX_DEFAULT_SITE_ENABLED}"
+}
+
+bangi_disable_packaged_nginx_default_site() {
+    local packaged_default="/etc/nginx/sites-enabled/default"
+
+    if [[ -L "${packaged_default}" ]]; then
+        rm -f "${packaged_default}" \
+            || bangi_fatal "Cannot disable packaged Nginx default site: ${packaged_default}"
+    fi
+}
+
+bangi_validate_nginx() {
+    bangi_log "Validating Nginx configuration"
+
+    nginx -t \
+        || bangi_fatal "Invalid Nginx configuration; fix Nginx errors before rerunning the installer"
+}
+
+bangi_reload_or_start_nginx() {
+    bangi_log "Reloading or starting Nginx"
+
+    if systemctl is-active --quiet nginx; then
+        systemctl reload nginx \
+            || bangi_fatal "Nginx reload failed after successful validation"
+        return 0
+    fi
+
+    systemctl start nginx \
+        || bangi_fatal "Nginx start failed after successful validation"
+}
+
 bangi_install_nginx() {
-    bangi_log "Nginx installation phase pending implementation"
+    bangi_log "Installing Bangi host Nginx baseline"
+
+    install -d -m 0755 -o root -g root "${BANGI_NGINX_AVAILABLE_DIR}" "${BANGI_NGINX_ENABLED_DIR}" \
+        || bangi_fatal "Cannot create Bangi Nginx workspace"
+
+    bangi_write_nginx_include
+    bangi_install_default_nginx_site
+    bangi_disable_packaged_nginx_default_site
+    bangi_validate_nginx
+    bangi_reload_or_start_nginx
 }

--- a/infra/installer/templates/nginx.default.conf
+++ b/infra/installer/templates/nginx.default.conf
@@ -1,0 +1,23 @@
+# Managed by Bangi installer. Local edits may be overwritten.
+server {
+    listen 80 default_server;
+    listen [::]:80 default_server;
+    server_name _;
+
+    access_log /var/log/nginx/bangi-access.log;
+    error_log /var/log/nginx/bangi-error.log;
+
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+
+    location /api/ {
+        proxy_pass http://127.0.0.1:8000;
+    }
+
+    location / {
+        proxy_pass http://127.0.0.1:8080;
+    }
+}


### PR DESCRIPTION
## Summary
- Installs the Bangi-managed Nginx include file at `/etc/nginx/conf.d/bangi.conf` so host Nginx loads `/etc/nginx/bangi/sites-enabled/*`.
- Adds the default Bangi HTTP site template for server-IP access, routing `/api/` to the API container port and all other requests to the web container port.
- Registers the Nginx template as a pinned deployment asset fetched into the release bundle.

## Scope
- Included: host installer Nginx setup, default web/API reverse proxy template, Nginx validation before reload/start, and release asset registration for the template.
- Not included: TLS/domain automation, public landing-renderer routing, campaign-specific virtual hosts, automated installer tests per KAN-31 guidance.

## Risks
- Low to moderate: this owns host Nginx default HTTP routing and disables the packaged default site symlink when present, so final behavior should be manually verified on an Ubuntu 24.04 host with `nginx -t` and local HTTP requests.

## Links
- Jira: https://bangitech.atlassian.net/browse/KAN-31
- Spec: `_bmad-output/planning-artifacts/bangi-host-provisioner-functional-spec.md`, `_bmad-output/planning-artifacts/bangi-host-provisioner-tech-spec.md`
