### PR TITLE
KAN-39: feat: Wire campaign-domain request routing and sticky-cookie behavior

### DIFF
--- a/apps/api/migrations/010_health_nginx_validation_snapshot.py
+++ b/apps/api/migrations/010_health_nginx_validation_snapshot.py
@@ -11,6 +11,7 @@ with suppress(ImportError):
 
 
 HEALTH_NGINX_VALIDATION_SNAPSHOT_TABLE = 'health_nginx_validation_snapshot'
+DOMAIN_COOKIE_TABLE = 'domain_cookie'
 
 
 def migrate(migrator: Migrator, database: pw.Database, *, fake=False):
@@ -29,8 +30,25 @@ def migrate(migrator: Migrator, database: pw.Database, *, fake=False):
         class Meta:
             table_name = HEALTH_NGINX_VALIDATION_SNAPSHOT_TABLE
 
+    @migrator.create_model
+    class DomainCookie(pw.Model):
+        id = pw.AutoField()
+        created_at = pw.TimestampField(null=True)
+        domain = pw.ForeignKeyField(
+            column_name='domain_id',
+            field='id',
+            model=migrator.orm['domain'],
+        )
+        name = pw.CharField(max_length=64)
+        opaque_name = pw.CharField(max_length=64)
+
+        class Meta:
+            table_name = DOMAIN_COOKIE_TABLE
+            indexes = ((('domain', 'name'), True), (('domain', 'opaque_name'), True))
+
 
 def rollback(migrator: Migrator, database: pw.Database, *, fake=False):
     """Write your rollback migrations here."""
 
+    migrator.remove_model(DOMAIN_COOKIE_TABLE)
     migrator.remove_model(HEALTH_NGINX_VALIDATION_SNAPSHOT_TABLE)

--- a/apps/api/src/container.py
+++ b/apps/api/src/container.py
@@ -12,7 +12,7 @@ from src.core.entities import database_proxy
 from src.core.repositories import CampaignRepository
 from src.core.services import CampaignService, ClientService, FlowService, Ip2LocationLocator
 from src.core.supervisor import WorkerContext, WorkerSupervisor
-from src.domains.services import DomainService, HostCommandExecutorService, NginxService
+from src.domains.services import DomainCookieService, DomainService, HostCommandExecutorService, NginxService
 from src.facebook_pacs.services import AdCabinetService as FacebookPacsAdCabinetService
 from src.facebook_pacs.services import BusinessPageService as FacebookPacsBusinessPageService
 from src.facebook_pacs.services import BusinessPortfolioService as FacebookPacsBusinessPortfolioService
@@ -49,7 +49,6 @@ container = create_sync_container(
         'IP2LOCATION_DB_PATH': _get_env('IP2LOCATION_DB_PATH'),
         'LANDING_PAGE_RENDERER_BASE_URL': _get_env('LANDING_PAGE_RENDERER_BASE_URL'),
         'INTERNAL_PROCESS_BASE_URL': _get_env('INTERNAL_PROCESS_BASE_URL'),
-        'FLOW_ID_COOKIE_KEY_LENGTH': _get_env('FLOW_ID_COOKIE_KEY_LENGTH', int, 6),
         'NGINX_WORKSPACE_BASE_DIR': _get_env('NGINX_WORKSPACE_BASE_DIR', str, '/etc/nginx/bangi'),
         'BANGI_HOST_OPS_SSH_USER': _get_env('BANGI_HOST_OPS_SSH_USER', str, 'bangi-ops'),
         'BANGI_HOST_OPS_SSH_HOST': _get_env('BANGI_HOST_OPS_SSH_HOST', str, 'host.docker.internal'),
@@ -70,6 +69,7 @@ container = create_sync_container(
         CampaignRepository,
         CampaignService,
         ClientService,
+        DomainCookieService,
         DomainService,
         HostCommandExecutorService,
         NginxService,

--- a/apps/api/src/core/services.py
+++ b/apps/api/src/core/services.py
@@ -322,7 +322,7 @@ class FlowService:
             Flow.select(fn.count(Flow.id)).where((Flow.is_deleted == False) & (Flow.campaign == campaign_id)).scalar()
         )
 
-    def process_flows(self, campaign_id: int, client: Client):
+    def process_flows(self, campaign_id: int, client: Client, cookie_value=None):
         flows = (
             Flow.select()
             .where((Flow.campaign_id == campaign_id) & (Flow.is_enabled == True) & (Flow.is_deleted == False))
@@ -347,8 +347,8 @@ class FlowService:
             return None, None, None
 
         if matched_flow.action_type == FlowActionType.redirect:
-            return matched_flow.action_type, matched_flow.redirect_url, matched_flow
+            return matched_flow.action_type, matched_flow.redirect_url, matched_flow.id
         elif matched_flow.action_type == FlowActionType.render:
-            return matched_flow.action_type, self._render_landing_page(matched_flow.id), matched_flow
+            return matched_flow.action_type, self._render_landing_page(matched_flow.id), matched_flow.id
 
-        return None, None, matched_flow
+        return None, None, matched_flow.id

--- a/apps/api/src/core/services.py
+++ b/apps/api/src/core/services.py
@@ -344,11 +344,11 @@ class FlowService:
             logger.warning(
                 'Failed to process flows', extra={'campaign_id': campaign_id, 'flows': [f.to_dict() for f in flows]}
             )
-            return None, None
+            return None, None, None
 
         if matched_flow.action_type == FlowActionType.redirect:
-            return matched_flow.action_type, matched_flow.redirect_url
+            return matched_flow.action_type, matched_flow.redirect_url, matched_flow
         elif matched_flow.action_type == FlowActionType.render:
-            return matched_flow.action_type, self._render_landing_page(matched_flow.id)
+            return matched_flow.action_type, self._render_landing_page(matched_flow.id), matched_flow
 
-        return None, None
+        return None, None, matched_flow

--- a/apps/api/src/domains/entities.py
+++ b/apps/api/src/domains/entities.py
@@ -12,3 +12,13 @@ class Domain(Entity):
 
     class Meta:
         table_name = 'domain'
+
+
+class DomainCookie(Entity):
+    domain = ForeignKeyField(Domain, on_delete='CASCADE')
+    name = CharField(max_length=64)
+    opaque_name = CharField(max_length=64)
+
+    class Meta:
+        table_name = 'domain_cookie'
+        indexes = ((('domain', 'name'), True), (('domain', 'opaque_name'), True))

--- a/apps/api/src/domains/enums.py
+++ b/apps/api/src/domains/enums.py
@@ -6,6 +6,10 @@ class DomainPurpose(str, Enum):
     dashboard = 'dashboard'
 
 
+class DomainCookieName(str, Enum):
+    flow_id = 'flow_id'
+
+
 class DomainSortBy(str, Enum):
     id = 'id'
     createdAt = 'createdAt'

--- a/apps/api/src/domains/routes.py
+++ b/apps/api/src/domains/routes.py
@@ -39,7 +39,6 @@ class Domains(MethodView):
                         'campaign_id': domain.campaign_id,
                         'is_a_record_set': (None if domain.is_a_record_set is None else bool(domain.is_a_record_set)),
                         'is_disabled': bool(domain.is_disabled),
-                        'cookie_name': domain_service.cookie_name(domain.hostname, domain.purpose),
                     }
                 )
                 for domain in domains
@@ -61,7 +60,6 @@ class Domains(MethodView):
                 'campaign_id': domain.campaign_id,
                 'is_a_record_set': None if domain.is_a_record_set is None else bool(domain.is_a_record_set),
                 'is_disabled': bool(domain.is_disabled),
-                'cookie_name': domain_service.cookie_name(domain.hostname, domain.purpose),
             }
         )
 
@@ -81,7 +79,6 @@ class Domain(MethodView):
                 'campaign_id': domain.campaign_id,
                 'is_a_record_set': None if domain.is_a_record_set is None else bool(domain.is_a_record_set),
                 'is_disabled': bool(domain.is_disabled),
-                'cookie_name': domain_service.cookie_name(domain.hostname, domain.purpose),
             }
         )
 
@@ -105,6 +102,5 @@ class Domain(MethodView):
                 'campaign_id': domain.campaign_id,
                 'is_a_record_set': None if domain.is_a_record_set is None else bool(domain.is_a_record_set),
                 'is_disabled': bool(domain.is_disabled),
-                'cookie_name': domain_service.cookie_name(domain.hostname, domain.purpose),
             }
         )

--- a/apps/api/src/domains/schemas.py
+++ b/apps/api/src/domains/schemas.py
@@ -67,7 +67,6 @@ class DomainResponseSchema(Schema):
     campaignId = fields.Integer(allow_none=True)
     isARecordSet = fields.Boolean(allow_none=True)
     isDisabled = fields.Boolean(required=True)
-    cookieName = fields.String(allow_none=True)
 
 
 class DomainListResponseSchema(Schema):

--- a/apps/api/src/domains/services.py
+++ b/apps/api/src/domains/services.py
@@ -137,6 +137,14 @@ class DomainService:
             return None
         return _cookie_name_for_hostname(hostname, self.flow_id_cookie_key_length)
 
+    def get_by_campaign_id(self, campaign_id):
+        domain = Domain.get_or_none(
+            (Domain.campaign == campaign_id) & (Domain.purpose == DomainPurpose.campaign) & (Domain.is_disabled == False)
+        )
+        if domain is None:
+            raise DomainDoesNotExistError()
+        return domain
+
     def _get_campaign(self, campaign_id):
         try:
             return Campaign.get_by_id(campaign_id)

--- a/apps/api/src/domains/services.py
+++ b/apps/api/src/domains/services.py
@@ -1,19 +1,20 @@
-import hashlib
 import logging
+import secrets
 import subprocess
 import time
+import string
 from pathlib import Path
 from typing import Annotated, Protocol
 from uuid import uuid4
 
-from peewee import fn
+from peewee import IntegrityError, fn
 from wireup import Inject, injectable
 
 from src.core.entities import Campaign
 from src.core.enums import SortOrder
 from src.core.exceptions import CampaignDoesNotExistError
-from src.domains.entities import Domain
-from src.domains.enums import DomainPurpose
+from src.domains.entities import Domain, DomainCookie
+from src.domains.enums import DomainCookieName, DomainPurpose
 from src.domains.exceptions import (
     CampaignAlreadyBoundError,
     DashboardDomainCannotAttachCampaignError,
@@ -24,9 +25,37 @@ from src.health.services import HealthService
 
 logger = logging.getLogger(__name__)
 
+@injectable
+class DomainCookieService:
+    def get_or_create_opaque_name(self, domain_id: int, name: DomainCookieName) -> str:
+        cookie_name = name.value
+        cookie = DomainCookie.get_or_none(
+            (DomainCookie.domain == domain_id) & (DomainCookie.name == cookie_name)
+        )
+        if cookie is not None:
+            return cookie.opaque_name
 
-def _cookie_name_for_hostname(hostname: str, length: int) -> str:
-    return hashlib.sha256(hostname.encode()).hexdigest()[:length]
+        while True:
+            opaque_name = self._generate_opaque_name()
+            try:
+                cookie = DomainCookie.create(domain=domain_id, name=cookie_name, opaque_name=opaque_name)
+            except IntegrityError:
+                # Another request may have created the logical cookie row already.
+                # Re-read first; if it still does not exist, the random opaque name likely collided.
+                cookie = DomainCookie.get_or_none(
+                    (DomainCookie.domain == domain_id) & (DomainCookie.name == cookie_name)
+                )
+                if cookie is not None:
+                    return cookie.opaque_name
+                continue
+
+            return cookie.opaque_name
+
+    @staticmethod
+    def _generate_opaque_name() -> str:
+        alphabet = string.ascii_lowercase + string.digits
+        length = secrets.randbelow(6) + 2
+        return ''.join(secrets.choice(alphabet) for _ in range(length))
 
 
 class WebserverService(Protocol):
@@ -39,12 +68,7 @@ class WebserverService(Protocol):
 
 @injectable
 class DomainService:
-    def __init__(
-        self,
-        flow_id_cookie_key_length: Annotated[int, Inject(config='FLOW_ID_COOKIE_KEY_LENGTH')],
-        webserver_service: WebserverService,
-    ):
-        self.flow_id_cookie_key_length = flow_id_cookie_key_length
+    def __init__(self, webserver_service: WebserverService):
         self.webserver_service = webserver_service
 
     def get(self, id):
@@ -131,11 +155,6 @@ class DomainService:
         if previous_hostname != domain.hostname and snapshot.validation_status == 'success':
             self.webserver_service.disable(previous_hostname)
         return domain
-
-    def cookie_name(self, hostname, purpose):
-        if purpose != DomainPurpose.campaign:
-            return None
-        return _cookie_name_for_hostname(hostname, self.flow_id_cookie_key_length)
 
     def get_by_campaign_id(self, campaign_id):
         domain = Domain.get_or_none(
@@ -224,12 +243,12 @@ class NginxService:
         self,
         health_service: HealthService,
         host_command_executor_service: HostCommandExecutorService,
-        flow_id_cookie_key_length: Annotated[int, Inject(config='FLOW_ID_COOKIE_KEY_LENGTH')],
+        domain_cookie_service: DomainCookieService,
         nginx_workspace_base_dir: Annotated[str, Inject(config='NGINX_WORKSPACE_BASE_DIR')],
     ):
         self.health_service = health_service
         self.host_command_executor_service = host_command_executor_service
-        self.flow_id_cookie_key_length = flow_id_cookie_key_length
+        self.domain_cookie_service = domain_cookie_service
         self.nginx_workspace_base_dir = Path(nginx_workspace_base_dir)
 
     def publish(self, hostname: str):
@@ -311,6 +330,10 @@ class NginxService:
             '        proxy_pass http://127.0.0.1:8000;\n'
             '    }\n'
             '\n'
+            '    location /process {\n'
+            '        return 404;\n'
+            '    }\n'
+            '\n'
             '    location / {\n'
             '        proxy_pass http://127.0.0.1:8080;\n'
             '    }\n'
@@ -318,7 +341,7 @@ class NginxService:
         )
 
     def _render_campaign_domain_config(self, domain: Domain) -> str:
-        cookie_name = _cookie_name_for_hostname(domain.hostname, self.flow_id_cookie_key_length)
+        cookie_name = self.domain_cookie_service.get_or_create_opaque_name(domain.id, DomainCookieName.flow_id)
         return (
             '# Managed by Bangi. Campaign domain.\n'
             'server {\n'

--- a/apps/api/src/domains/services.py
+++ b/apps/api/src/domains/services.py
@@ -25,6 +25,10 @@ from src.health.services import HealthService
 logger = logging.getLogger(__name__)
 
 
+def _cookie_name_for_hostname(hostname: str, length: int) -> str:
+    return hashlib.sha256(hostname.encode()).hexdigest()[:length]
+
+
 class WebserverService(Protocol):
     def publish(self, hostname: str):
         pass
@@ -131,7 +135,7 @@ class DomainService:
     def cookie_name(self, hostname, purpose):
         if purpose != DomainPurpose.campaign:
             return None
-        return hashlib.sha256(hostname.encode()).hexdigest()[: self.flow_id_cookie_key_length]
+        return _cookie_name_for_hostname(hostname, self.flow_id_cookie_key_length)
 
     def _get_campaign(self, campaign_id):
         try:
@@ -212,10 +216,12 @@ class NginxService:
         self,
         health_service: HealthService,
         host_command_executor_service: HostCommandExecutorService,
+        flow_id_cookie_key_length: Annotated[int, Inject(config='FLOW_ID_COOKIE_KEY_LENGTH')],
         nginx_workspace_base_dir: Annotated[str, Inject(config='NGINX_WORKSPACE_BASE_DIR')],
     ):
         self.health_service = health_service
         self.host_command_executor_service = host_command_executor_service
+        self.flow_id_cookie_key_length = flow_id_cookie_key_length
         self.nginx_workspace_base_dir = Path(nginx_workspace_base_dir)
 
     def publish(self, hostname: str):
@@ -303,8 +309,8 @@ class NginxService:
             '}\n'
         )
 
-    @staticmethod
-    def _render_campaign_domain_config(domain: Domain) -> str:
+    def _render_campaign_domain_config(self, domain: Domain) -> str:
+        cookie_name = _cookie_name_for_hostname(domain.hostname, self.flow_id_cookie_key_length)
         return (
             '# Managed by Bangi. Campaign domain.\n'
             'server {\n'
@@ -312,12 +318,21 @@ class NginxService:
             '    listen [::]:80;\n'
             f'    server_name {domain.hostname};\n'
             '\n'
+            f'    set $bangi_campaign_upstream "http://127.0.0.1:8000/process/{domain.campaign_id}";\n'
+            f'    if ($cookie_{cookie_name} != "") {{\n'
+            f'        set $bangi_campaign_upstream "http://127.0.0.1:8081/$cookie_{cookie_name}/";\n'
+            '    }\n'
+            '\n'
             '    location = / {\n'
-            f'        proxy_pass http://127.0.0.1:8000/process/{domain.campaign_id};\n'
+            '        proxy_pass $bangi_campaign_upstream;\n'
             '    }\n'
             '\n'
             '    location / {\n'
-            '        return 404;\n'
+            f'        if ($cookie_{cookie_name} = "") {{\n'
+            '            return 404;\n'
+            '        }\n'
+            '\n'
+            f'        proxy_pass http://127.0.0.1:8081/$cookie_{cookie_name}/;\n'
             '    }\n'
             '}\n'
         )

--- a/apps/api/src/domains/services.py
+++ b/apps/api/src/domains/services.py
@@ -1,8 +1,8 @@
 import logging
 import secrets
+import string
 import subprocess
 import time
-import string
 from pathlib import Path
 from typing import Annotated, Protocol
 from uuid import uuid4
@@ -25,13 +25,12 @@ from src.health.services import HealthService
 
 logger = logging.getLogger(__name__)
 
+
 @injectable
 class DomainCookieService:
     def get_or_create_opaque_name(self, domain_id: int, name: DomainCookieName) -> str:
         cookie_name = name.value
-        cookie = DomainCookie.get_or_none(
-            (DomainCookie.domain == domain_id) & (DomainCookie.name == cookie_name)
-        )
+        cookie = DomainCookie.get_or_none((DomainCookie.domain == domain_id) & (DomainCookie.name == cookie_name))
         if cookie is not None:
             return cookie.opaque_name
 
@@ -158,7 +157,9 @@ class DomainService:
 
     def get_by_campaign_id(self, campaign_id):
         domain = Domain.get_or_none(
-            (Domain.campaign == campaign_id) & (Domain.purpose == DomainPurpose.campaign) & (Domain.is_disabled == False)
+            (Domain.campaign == campaign_id)
+            & (Domain.purpose == DomainPurpose.campaign)
+            & (Domain.is_disabled == False)
         )
         if domain is None:
             raise DomainDoesNotExistError()

--- a/apps/api/src/tracker/routes.py
+++ b/apps/api/src/tracker/routes.py
@@ -7,6 +7,9 @@ from src.container import container
 from src.core.blueprint import Blueprint
 from src.core.enums import FlowActionType
 from src.core.services import ClientService, FlowService
+from src.domains.entities import Domain
+from src.domains.enums import DomainPurpose
+from src.domains.services import DomainService
 from src.tracker.schemas import (
     TrackClickRequestSchema,
     TrackLeadRequestSchema,
@@ -83,12 +86,24 @@ class Process(MethodView):
         client = client_service.client_info(
             request.user_agent.string, request.environ.get('HTTP_X_REAL_IP', request.remote_addr)
         )
-        action_type, subject = flow_service.process_flows(campaignId, client)
+        action_type, subject, matched_flow = flow_service.process_flows(campaignId, client)
 
         if action_type == FlowActionType.redirect:
             return redirect(subject)
         elif action_type == FlowActionType.render:
-            return make_response(subject)
+            response = make_response(subject)
+            if matched_flow is not None:
+                domain = Domain.get_or_none((Domain.campaign == campaignId) & (Domain.purpose == DomainPurpose.campaign))
+                if domain is not None:
+                    domain_service = container.get(DomainService)
+                    response.set_cookie(
+                        domain_service.cookie_name(domain.hostname, domain.purpose),
+                        str(matched_flow.id),
+                        httponly=True,
+                        path='/',
+                        max_age=60 * 60 * 24 * 365,
+                    )
+            return response
         else:
             track_click_service.track_discard(click_id, campaignId, client)
             return make_response('')

--- a/apps/api/src/tracker/routes.py
+++ b/apps/api/src/tracker/routes.py
@@ -7,8 +7,6 @@ from src.container import container
 from src.core.blueprint import Blueprint
 from src.core.enums import FlowActionType
 from src.core.services import ClientService, FlowService
-from src.domains.entities import Domain
-from src.domains.enums import DomainPurpose
 from src.domains.services import DomainService
 from src.tracker.schemas import (
     TrackClickRequestSchema,
@@ -76,6 +74,7 @@ class Process(MethodView):
         track_click_service = container.get(TrackService)
         client_service = container.get(ClientService)
         flow_service = container.get(FlowService)
+        domain_service = container.get(DomainService)
 
         click_id = process_payload.pop('clickId', None)
         if click_id is None:
@@ -86,24 +85,26 @@ class Process(MethodView):
         client = client_service.client_info(
             request.user_agent.string, request.environ.get('HTTP_X_REAL_IP', request.remote_addr)
         )
-        action_type, subject, matched_flow = flow_service.process_flows(campaignId, client)
+        domain = domain_service.get_by_campaign_id(campaignId)
+        cookie_name = domain_service.cookie_name(domain.hostname, domain.purpose)
+        cookie_value = request.cookies.get(cookie_name)
+        action_type, subject, flow_id = flow_service.process_flows(campaignId, client, cookie_value)
 
         if action_type == FlowActionType.redirect:
-            return redirect(subject)
+            response = redirect(subject)
         elif action_type == FlowActionType.render:
             response = make_response(subject)
-            if matched_flow is not None:
-                domain = Domain.get_or_none((Domain.campaign == campaignId) & (Domain.purpose == DomainPurpose.campaign))
-                if domain is not None:
-                    domain_service = container.get(DomainService)
-                    response.set_cookie(
-                        domain_service.cookie_name(domain.hostname, domain.purpose),
-                        str(matched_flow.id),
-                        httponly=True,
-                        path='/',
-                        max_age=60 * 60 * 24 * 365,
-                    )
-            return response
         else:
             track_click_service.track_discard(click_id, campaignId, client)
             return make_response('')
+
+        if flow_id is not None:
+            response.set_cookie(
+                cookie_name,
+                str(flow_id),
+                httponly=True,
+                path='/',
+                max_age=60 * 60 * 24 * 365,
+            )
+
+        return response

--- a/apps/api/src/tracker/routes.py
+++ b/apps/api/src/tracker/routes.py
@@ -7,7 +7,8 @@ from src.container import container
 from src.core.blueprint import Blueprint
 from src.core.enums import FlowActionType
 from src.core.services import ClientService, FlowService
-from src.domains.services import DomainService
+from src.domains.enums import DomainCookieName
+from src.domains.services import DomainCookieService, DomainService
 from src.tracker.schemas import (
     TrackClickRequestSchema,
     TrackLeadRequestSchema,
@@ -71,10 +72,13 @@ class Process(MethodView):
     @process_blueprint.arguments(TrackProcessRequestSchema, location='query')
     @process_blueprint.response(200)
     def get(self, process_payload, campaignId):
+        domain_service = container.get(DomainService)
+        domain = domain_service.get_by_campaign_id(campaignId)
+
         track_click_service = container.get(TrackService)
         client_service = container.get(ClientService)
         flow_service = container.get(FlowService)
-        domain_service = container.get(DomainService)
+        cookie_service = container.get(DomainCookieService)
 
         click_id = process_payload.pop('clickId', None)
         if click_id is None:
@@ -85,8 +89,7 @@ class Process(MethodView):
         client = client_service.client_info(
             request.user_agent.string, request.environ.get('HTTP_X_REAL_IP', request.remote_addr)
         )
-        domain = domain_service.get_by_campaign_id(campaignId)
-        cookie_name = domain_service.cookie_name(domain.hostname, domain.purpose)
+        cookie_name = cookie_service.get_or_create_opaque_name(domain.id, DomainCookieName.flow_id)
         cookie_value = request.cookies.get(cookie_name)
         action_type, subject, flow_id = flow_service.process_flows(campaignId, client, cookie_value)
 

--- a/apps/api/tests/fixtures/entities.py
+++ b/apps/api/tests/fixtures/entities.py
@@ -12,14 +12,14 @@ def flow(write_to_db, flow_payload, campaign):
 
 
 @pytest.fixture
-def domain(write_to_db):
+def domain(write_to_db, campaign):
     return write_to_db(
         'domain',
         {
-            'hostname': 'example.com',
+            'hostname': 'campaign.example.com',
             'purpose': 'campaign',
-            'campaign_id': None,
-            'is_a_record_set': None,
+            'campaign_id': campaign['id'],
+            'is_a_record_set': True,
             'is_disabled': False,
         },
     )

--- a/apps/api/tests/fixtures/utils.py
+++ b/apps/api/tests/fixtures/utils.py
@@ -1,3 +1,4 @@
+import hashlib
 import time
 from datetime import datetime, timezone
 from uuid import UUID
@@ -7,6 +8,10 @@ import pytest
 
 def click_uuid(value):
     return UUID(f'00000000-0000-0000-0000-{value:012d}')
+
+
+def cookie_name(hostname, length=6):
+    return hashlib.sha256(hostname.encode()).hexdigest()[:length]
 
 
 @pytest.fixture

--- a/apps/api/tests/fixtures/utils.py
+++ b/apps/api/tests/fixtures/utils.py
@@ -1,4 +1,3 @@
-import hashlib
 import time
 from datetime import datetime, timezone
 from uuid import UUID
@@ -8,10 +7,6 @@ import pytest
 
 def click_uuid(value):
     return UUID(f'00000000-0000-0000-0000-{value:012d}')
-
-
-def cookie_name(hostname, length=6):
-    return hashlib.sha256(hostname.encode()).hexdigest()[:length]
 
 
 @pytest.fixture

--- a/apps/api/tests/integration/domains/test_domains.py
+++ b/apps/api/tests/integration/domains/test_domains.py
@@ -1,11 +1,7 @@
-import hashlib
 from unittest import mock
 
 import pytest
-
-
-def _cookie_name(hostname, length=6):
-    return hashlib.sha256(hostname.encode()).hexdigest()[:length]
+from fixtures.utils import cookie_name
 
 
 class TestDomains:
@@ -26,7 +22,7 @@ class TestDomains:
             'campaignId': None,
             'isARecordSet': None,
             'isDisabled': False,
-            'cookieName': _cookie_name('example.com'),
+            'cookieName': cookie_name('example.com'),
         }
 
         domain = read_from_db('domain')
@@ -84,7 +80,7 @@ class TestDomains:
             'campaignId': None,
             'isARecordSet': None,
             'isDisabled': False,
-            'cookieName': _cookie_name('padding-0.example.com'),
+            'cookieName': cookie_name('padding-0.example.com'),
         }
         assert response.json['content'][-1] == {
             'id': mock.ANY,
@@ -93,7 +89,7 @@ class TestDomains:
             'campaignId': campaign_domain['campaign_id'],
             'isARecordSet': campaign_domain['is_a_record_set'],
             'isDisabled': campaign_domain['is_disabled'],
-            'cookieName': _cookie_name(campaign_domain['hostname']),
+            'cookieName': cookie_name(campaign_domain['hostname']),
         }
         assert dashboard_domain['hostname'] not in {item['hostname'] for item in response.json['content']}
         assert response.json['pagination'] == {
@@ -161,7 +157,7 @@ class TestDomains:
                     'campaignId': first['campaign_id'],
                     'isARecordSet': first['is_a_record_set'],
                     'isDisabled': first['is_disabled'],
-                    'cookieName': _cookie_name(first['hostname']),
+                    'cookieName': cookie_name(first['hostname']),
                 },
                 {
                     'id': second['id'],
@@ -170,7 +166,7 @@ class TestDomains:
                     'campaignId': second['campaign_id'],
                     'isARecordSet': second['is_a_record_set'],
                     'isDisabled': second['is_disabled'],
-                    'cookieName': _cookie_name(second['hostname']),
+                    'cookieName': cookie_name(second['hostname']),
                 },
             ],
             'pagination': {'page': 1, 'pageSize': 3, 'sortBy': 'hostname', 'sortOrder': 'desc', 'total': 3},
@@ -187,7 +183,7 @@ class TestDomains:
             'campaignId': domain['campaign_id'],
             'isARecordSet': domain['is_a_record_set'],
             'isDisabled': domain['is_disabled'],
-            'cookieName': _cookie_name(domain['hostname']),
+            'cookieName': cookie_name(domain['hostname']),
         }
 
     def test_get_domain__non_existent(self, client, authorization):
@@ -228,7 +224,7 @@ class TestDomains:
             'campaignId': None,
             'isARecordSet': None,
             'isDisabled': False,
-            'cookieName': _cookie_name('new.example.com'),
+            'cookieName': cookie_name('new.example.com'),
         }
 
         updated = read_from_db('domain', filters={'id': domain['id']})
@@ -276,7 +272,7 @@ class TestDomains:
             'campaignId': campaign['id'],
             'isARecordSet': True,
             'isDisabled': False,
-            'cookieName': _cookie_name(domain['hostname']),
+            'cookieName': cookie_name(domain['hostname']),
         }
 
         updated = read_from_db('domain', filters={'id': domain['id']})

--- a/apps/api/tests/integration/domains/test_domains.py
+++ b/apps/api/tests/integration/domains/test_domains.py
@@ -1,11 +1,10 @@
 from unittest import mock
 
 import pytest
-from fixtures.utils import cookie_name
 
 
 class TestDomains:
-    def test_create_domain_normalizes_hostname_and_returns_cookie_name(self, client, authorization, read_from_db):
+    def test_create_domain_normalizes_hostname_and_returns_full_payload(self, client, authorization, read_from_db):
         request_payload = {
             'hostname': 'Example.COM.',
             'purpose': 'campaign',
@@ -22,7 +21,6 @@ class TestDomains:
             'campaignId': None,
             'isARecordSet': None,
             'isDisabled': False,
-            'cookieName': cookie_name('example.com'),
         }
 
         domain = read_from_db('domain')
@@ -80,7 +78,6 @@ class TestDomains:
             'campaignId': None,
             'isARecordSet': None,
             'isDisabled': False,
-            'cookieName': cookie_name('padding-0.example.com'),
         }
         assert response.json['content'][-1] == {
             'id': mock.ANY,
@@ -89,7 +86,6 @@ class TestDomains:
             'campaignId': campaign_domain['campaign_id'],
             'isARecordSet': campaign_domain['is_a_record_set'],
             'isDisabled': campaign_domain['is_disabled'],
-            'cookieName': cookie_name(campaign_domain['hostname']),
         }
         assert dashboard_domain['hostname'] not in {item['hostname'] for item in response.json['content']}
         assert response.json['pagination'] == {
@@ -148,7 +144,6 @@ class TestDomains:
                     'campaignId': third['campaign_id'],
                     'isARecordSet': third['is_a_record_set'],
                     'isDisabled': third['is_disabled'],
-                    'cookieName': None,
                 },
                 {
                     'id': first['id'],
@@ -157,7 +152,6 @@ class TestDomains:
                     'campaignId': first['campaign_id'],
                     'isARecordSet': first['is_a_record_set'],
                     'isDisabled': first['is_disabled'],
-                    'cookieName': cookie_name(first['hostname']),
                 },
                 {
                     'id': second['id'],
@@ -166,7 +160,6 @@ class TestDomains:
                     'campaignId': second['campaign_id'],
                     'isARecordSet': second['is_a_record_set'],
                     'isDisabled': second['is_disabled'],
-                    'cookieName': cookie_name(second['hostname']),
                 },
             ],
             'pagination': {'page': 1, 'pageSize': 3, 'sortBy': 'hostname', 'sortOrder': 'desc', 'total': 3},
@@ -183,7 +176,6 @@ class TestDomains:
             'campaignId': domain['campaign_id'],
             'isARecordSet': domain['is_a_record_set'],
             'isDisabled': domain['is_disabled'],
-            'cookieName': cookie_name(domain['hostname']),
         }
 
     def test_get_domain__non_existent(self, client, authorization):
@@ -224,7 +216,6 @@ class TestDomains:
             'campaignId': None,
             'isARecordSet': None,
             'isDisabled': False,
-            'cookieName': cookie_name('new.example.com'),
         }
 
         updated = read_from_db('domain', filters={'id': domain['id']})
@@ -272,7 +263,6 @@ class TestDomains:
             'campaignId': campaign['id'],
             'isARecordSet': True,
             'isDisabled': False,
-            'cookieName': cookie_name(domain['hostname']),
         }
 
         updated = read_from_db('domain', filters={'id': domain['id']})
@@ -418,7 +408,6 @@ class TestDomains:
             'campaignId': None,
             'isARecordSet': True,
             'isDisabled': False,
-            'cookieName': None,
         }
 
         updated = read_from_db('domain', filters={'id': domain['id']})
@@ -481,7 +470,6 @@ class TestDomains:
             'campaignId': None,
             'isARecordSet': True,
             'isDisabled': False,
-            'cookieName': None,
         }
 
         updated = read_from_db('domain', filters={'id': domain['id']})

--- a/apps/api/tests/integration/domains/test_nginx.py
+++ b/apps/api/tests/integration/domains/test_nginx.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from unittest import mock
 
 import pytest
-from fixtures.utils import cookie_name
 
 
 @pytest.fixture
@@ -265,6 +264,7 @@ class TestDomainNginxConfigurations:
         authorization,
         campaign,
         nginx_workspace_base_dir,
+        read_from_db,
         write_to_db,
     ):
         hostname = 'campaign-attached.example.com'
@@ -288,6 +288,14 @@ class TestDomainNginxConfigurations:
         assert response.status_code == 200, response.text
         available_dir = Path(nginx_workspace_base_dir) / 'sites-available' / hostname
         versioned_configs = sorted(available_dir.glob('*.conf'))
+        cookie_row = read_from_db('domain_cookie', filters={'domain_id': domain['id'], 'name': 'flow_id'})
+        assert cookie_row == {
+            'id': mock.ANY,
+            'created_at': mock.ANY,
+            'domain_id': domain['id'],
+            'name': 'flow_id',
+            'opaque_name': mock.ANY,
+        }
 
         assert len(versioned_configs) == 1
         assert versioned_configs[0].read_text(encoding='utf-8') == (
@@ -298,8 +306,8 @@ class TestDomainNginxConfigurations:
             f'    server_name {hostname};\n'
             '\n'
             f'    set $bangi_campaign_upstream "http://127.0.0.1:8000/process/{campaign["id"]}";\n'
-            f'    if ($cookie_{cookie_name(hostname)} != "") {{\n'
-            f'        set $bangi_campaign_upstream "http://127.0.0.1:8081/$cookie_{cookie_name(hostname)}/";\n'
+            f'    if ($cookie_{cookie_row["opaque_name"]} != "") {{\n'
+            f'        set $bangi_campaign_upstream "http://127.0.0.1:8081/$cookie_{cookie_row["opaque_name"]}/";\n'
             '    }\n'
             '\n'
             '    location = / {\n'
@@ -307,11 +315,11 @@ class TestDomainNginxConfigurations:
             '    }\n'
             '\n'
             '    location / {\n'
-            f'        if ($cookie_{cookie_name(hostname)} = "") {{\n'
+            f'        if ($cookie_{cookie_row["opaque_name"]} = "") {{\n'
             '            return 404;\n'
             '        }\n'
             '\n'
-            f'        proxy_pass http://127.0.0.1:8081/$cookie_{cookie_name(hostname)}/;\n'
+            f'        proxy_pass http://127.0.0.1:8081/$cookie_{cookie_row["opaque_name"]}/;\n'
             '    }\n'
             '}\n'
         )
@@ -398,6 +406,10 @@ class TestDomainNginxConfigurations:
             '        proxy_pass http://127.0.0.1:8000;\n'
             '    }\n'
             '\n'
+            '    location /process {\n'
+            '        return 404;\n'
+            '    }\n'
+            '\n'
             '    location / {\n'
             '        proxy_pass http://127.0.0.1:8080;\n'
             '    }\n'
@@ -426,6 +438,10 @@ class TestDomainNginxConfigurations:
             '\n'
             '    location /api/ {\n'
             '        proxy_pass http://127.0.0.1:8000;\n'
+            '    }\n'
+            '\n'
+            '    location /process {\n'
+            '        return 404;\n'
             '    }\n'
             '\n'
             '    location / {\n'
@@ -480,6 +496,7 @@ class TestDomainNginxConfigurations:
         authorization,
         campaign,
         nginx_workspace_base_dir,
+        read_from_db,
         write_to_db,
     ):
         hostname = 'dashboard-attached.example.com'
@@ -503,6 +520,14 @@ class TestDomainNginxConfigurations:
         assert response.status_code == 200, response.text
         available_dir = Path(nginx_workspace_base_dir) / 'sites-available' / hostname
         versioned_configs = sorted(available_dir.glob('*.conf'))
+        cookie_row = read_from_db('domain_cookie', filters={'domain_id': domain['id'], 'name': 'flow_id'})
+        assert cookie_row == {
+            'id': mock.ANY,
+            'created_at': mock.ANY,
+            'domain_id': domain['id'],
+            'name': 'flow_id',
+            'opaque_name': mock.ANY,
+        }
 
         assert len(versioned_configs) == 1
         assert versioned_configs[0].read_text(encoding='utf-8') == (
@@ -513,8 +538,8 @@ class TestDomainNginxConfigurations:
             f'    server_name {hostname};\n'
             '\n'
             f'    set $bangi_campaign_upstream "http://127.0.0.1:8000/process/{campaign["id"]}";\n'
-            f'    if ($cookie_{cookie_name(hostname)} != "") {{\n'
-            f'        set $bangi_campaign_upstream "http://127.0.0.1:8081/$cookie_{cookie_name(hostname)}/";\n'
+            f'    if ($cookie_{cookie_row["opaque_name"]} != "") {{\n'
+            f'        set $bangi_campaign_upstream "http://127.0.0.1:8081/$cookie_{cookie_row["opaque_name"]}/";\n'
             '    }\n'
             '\n'
             '    location = / {\n'
@@ -522,11 +547,11 @@ class TestDomainNginxConfigurations:
             '    }\n'
             '\n'
             '    location / {\n'
-            f'        if ($cookie_{cookie_name(hostname)} = "") {{\n'
+            f'        if ($cookie_{cookie_row["opaque_name"]} = "") {{\n'
             '            return 404;\n'
             '        }\n'
             '\n'
-            f'        proxy_pass http://127.0.0.1:8081/$cookie_{cookie_name(hostname)}/;\n'
+            f'        proxy_pass http://127.0.0.1:8081/$cookie_{cookie_row["opaque_name"]}/;\n'
             '    }\n'
             '}\n'
         )

--- a/apps/api/tests/integration/domains/test_nginx.py
+++ b/apps/api/tests/integration/domains/test_nginx.py
@@ -1,15 +1,11 @@
 import json
-import hashlib
 import os
 import shutil
 from pathlib import Path
 from unittest import mock
 
 import pytest
-
-
-def _cookie_name(hostname, length=6):
-    return hashlib.sha256(hostname.encode()).hexdigest()[:length]
+from fixtures.utils import cookie_name
 
 
 @pytest.fixture
@@ -302,8 +298,8 @@ class TestDomainNginxConfigurations:
             f'    server_name {hostname};\n'
             '\n'
             f'    set $bangi_campaign_upstream "http://127.0.0.1:8000/process/{campaign["id"]}";\n'
-            f'    if ($cookie_{_cookie_name(hostname)} != "") {{\n'
-            f'        set $bangi_campaign_upstream "http://127.0.0.1:8081/$cookie_{_cookie_name(hostname)}/";\n'
+            f'    if ($cookie_{cookie_name(hostname)} != "") {{\n'
+            f'        set $bangi_campaign_upstream "http://127.0.0.1:8081/$cookie_{cookie_name(hostname)}/";\n'
             '    }\n'
             '\n'
             '    location = / {\n'
@@ -311,11 +307,11 @@ class TestDomainNginxConfigurations:
             '    }\n'
             '\n'
             '    location / {\n'
-            f'        if ($cookie_{_cookie_name(hostname)} = "") {{\n'
+            f'        if ($cookie_{cookie_name(hostname)} = "") {{\n'
             '            return 404;\n'
             '        }\n'
             '\n'
-            f'        proxy_pass http://127.0.0.1:8081/$cookie_{_cookie_name(hostname)}/;\n'
+            f'        proxy_pass http://127.0.0.1:8081/$cookie_{cookie_name(hostname)}/;\n'
             '    }\n'
             '}\n'
         )
@@ -517,8 +513,8 @@ class TestDomainNginxConfigurations:
             f'    server_name {hostname};\n'
             '\n'
             f'    set $bangi_campaign_upstream "http://127.0.0.1:8000/process/{campaign["id"]}";\n'
-            f'    if ($cookie_{_cookie_name(hostname)} != "") {{\n'
-            f'        set $bangi_campaign_upstream "http://127.0.0.1:8081/$cookie_{_cookie_name(hostname)}/";\n'
+            f'    if ($cookie_{cookie_name(hostname)} != "") {{\n'
+            f'        set $bangi_campaign_upstream "http://127.0.0.1:8081/$cookie_{cookie_name(hostname)}/";\n'
             '    }\n'
             '\n'
             '    location = / {\n'
@@ -526,11 +522,11 @@ class TestDomainNginxConfigurations:
             '    }\n'
             '\n'
             '    location / {\n'
-            f'        if ($cookie_{_cookie_name(hostname)} = "") {{\n'
+            f'        if ($cookie_{cookie_name(hostname)} = "") {{\n'
             '            return 404;\n'
             '        }\n'
             '\n'
-            f'        proxy_pass http://127.0.0.1:8081/$cookie_{_cookie_name(hostname)}/;\n'
+            f'        proxy_pass http://127.0.0.1:8081/$cookie_{cookie_name(hostname)}/;\n'
             '    }\n'
             '}\n'
         )

--- a/apps/api/tests/integration/domains/test_nginx.py
+++ b/apps/api/tests/integration/domains/test_nginx.py
@@ -1,10 +1,15 @@
 import json
+import hashlib
 import os
 import shutil
 from pathlib import Path
 from unittest import mock
 
 import pytest
+
+
+def _cookie_name(hostname, length=6):
+    return hashlib.sha256(hostname.encode()).hexdigest()[:length]
 
 
 @pytest.fixture
@@ -296,12 +301,21 @@ class TestDomainNginxConfigurations:
             '    listen [::]:80;\n'
             f'    server_name {hostname};\n'
             '\n'
+            f'    set $bangi_campaign_upstream "http://127.0.0.1:8000/process/{campaign["id"]}";\n'
+            f'    if ($cookie_{_cookie_name(hostname)} != "") {{\n'
+            f'        set $bangi_campaign_upstream "http://127.0.0.1:8081/$cookie_{_cookie_name(hostname)}/";\n'
+            '    }\n'
+            '\n'
             '    location = / {\n'
-            f'        proxy_pass http://127.0.0.1:8000/process/{campaign["id"]};\n'
+            '        proxy_pass $bangi_campaign_upstream;\n'
             '    }\n'
             '\n'
             '    location / {\n'
-            '        return 404;\n'
+            f'        if ($cookie_{_cookie_name(hostname)} = "") {{\n'
+            '            return 404;\n'
+            '        }\n'
+            '\n'
+            f'        proxy_pass http://127.0.0.1:8081/$cookie_{_cookie_name(hostname)}/;\n'
             '    }\n'
             '}\n'
         )
@@ -502,12 +516,21 @@ class TestDomainNginxConfigurations:
             '    listen [::]:80;\n'
             f'    server_name {hostname};\n'
             '\n'
+            f'    set $bangi_campaign_upstream "http://127.0.0.1:8000/process/{campaign["id"]}";\n'
+            f'    if ($cookie_{_cookie_name(hostname)} != "") {{\n'
+            f'        set $bangi_campaign_upstream "http://127.0.0.1:8081/$cookie_{_cookie_name(hostname)}/";\n'
+            '    }\n'
+            '\n'
             '    location = / {\n'
-            f'        proxy_pass http://127.0.0.1:8000/process/{campaign["id"]};\n'
+            '        proxy_pass $bangi_campaign_upstream;\n'
             '    }\n'
             '\n'
             '    location / {\n'
-            '        return 404;\n'
+            f'        if ($cookie_{_cookie_name(hostname)} = "") {{\n'
+            '            return 404;\n'
+            '        }\n'
+            '\n'
+            f'        proxy_pass http://127.0.0.1:8081/$cookie_{_cookie_name(hostname)}/;\n'
             '    }\n'
             '}\n'
         )

--- a/apps/api/tests/integration/track/test_process.py
+++ b/apps/api/tests/integration/track/test_process.py
@@ -1,19 +1,15 @@
 import json
-import hashlib
 from unittest import mock
 from uuid import UUID, uuid4
 
 import httpx
 import pytest
+from fixtures.utils import cookie_name
 
 MOBILE_SAFARI_USER_AGENT = (
     'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) '
     'AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1'
 )
-
-
-def _cookie_name(hostname, length=6):
-    return hashlib.sha256(hostname.encode()).hexdigest()[:length]
 
 
 @pytest.fixture
@@ -410,6 +406,15 @@ class TestTrackLanding:
                 'is_deleted': False,
             },
         )
+        respx_mock.get(f'{environment["LANDING_PAGE_RENDERER_BASE_URL"]}/{render_flow["id"]}/').mock(
+            httpx.Response(status_code=200, text='<html>Sticky landing</html>')
+        )
+
+        response = client.get(f'/process/{campaign["id"]}', query_string={'clickId': str(uuid4())})
+
+        assert response.status_code == 200, response.text
+        assert response.text == '<html>Sticky landing</html>'
+
         hostname = 'campaign.example.com'
         write_to_db(
             'domain',
@@ -421,17 +426,9 @@ class TestTrackLanding:
                 'is_disabled': False,
             },
         )
-        respx_mock.get(f'{environment["LANDING_PAGE_RENDERER_BASE_URL"]}/{render_flow["id"]}/').mock(
-            httpx.Response(status_code=200, text='<html>Sticky landing</html>')
-        )
-
-        response = client.get(f'/process/{campaign["id"]}', query_string={'clickId': str(uuid4())})
-
-        assert response.status_code == 200, response.text
-        assert response.text == '<html>Sticky landing</html>'
 
         cookie_header = response.headers['Set-Cookie']
-        assert _cookie_name(hostname) in cookie_header
+        assert cookie_name(hostname) in cookie_header
         assert f'={render_flow["id"]}' in cookie_header
         assert 'HttpOnly' in cookie_header
         assert 'Max-Age=31536000' in cookie_header

--- a/apps/api/tests/integration/track/test_process.py
+++ b/apps/api/tests/integration/track/test_process.py
@@ -1,4 +1,5 @@
 import json
+import hashlib
 from unittest import mock
 from uuid import UUID, uuid4
 
@@ -9,6 +10,10 @@ MOBILE_SAFARI_USER_AGENT = (
     'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) '
     'AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1'
 )
+
+
+def _cookie_name(hostname, length=6):
+    return hashlib.sha256(hostname.encode()).hexdigest()[:length]
 
 
 @pytest.fixture
@@ -388,3 +393,46 @@ class TestTrackLanding:
             'status': request_payload['status'],
             'tid': request_payload['tid'],
         }
+
+    def test_track_landing__sets_domain_sticky_cookie_on_first_visit(
+        self, client, campaign, environment, write_to_db, ip2location_mock, respx_mock
+    ):
+        render_flow = write_to_db(
+            'flow',
+            {
+                'name': 'Render flow',
+                'campaign_id': campaign['id'],
+                'rule': None,
+                'order_value': 1,
+                'action_type': 'render',
+                'redirect_url': None,
+                'is_enabled': True,
+                'is_deleted': False,
+            },
+        )
+        hostname = 'campaign.example.com'
+        write_to_db(
+            'domain',
+            {
+                'hostname': hostname,
+                'purpose': 'campaign',
+                'campaign_id': campaign['id'],
+                'is_a_record_set': True,
+                'is_disabled': False,
+            },
+        )
+        respx_mock.get(f'{environment["LANDING_PAGE_RENDERER_BASE_URL"]}/{render_flow["id"]}/').mock(
+            httpx.Response(status_code=200, text='<html>Sticky landing</html>')
+        )
+
+        response = client.get(f'/process/{campaign["id"]}', query_string={'clickId': str(uuid4())})
+
+        assert response.status_code == 200, response.text
+        assert response.text == '<html>Sticky landing</html>'
+
+        cookie_header = response.headers['Set-Cookie']
+        assert _cookie_name(hostname) in cookie_header
+        assert f'={render_flow["id"]}' in cookie_header
+        assert 'HttpOnly' in cookie_header
+        assert 'Max-Age=31536000' in cookie_header
+        assert 'Path=/' in cookie_header

--- a/apps/api/tests/integration/track/test_process.py
+++ b/apps/api/tests/integration/track/test_process.py
@@ -433,3 +433,28 @@ class TestTrackLanding:
         assert 'HttpOnly' in cookie_header
         assert 'Max-Age=31536000' in cookie_header
         assert 'Path=/' in cookie_header
+
+    def test_track_landing__returns_404_when_campaign_domain_is_missing(self, client, campaign):
+        response = client.get(f'/process/{campaign["id"]}', query_string={'clickId': str(uuid4())})
+
+        assert response.status_code == 404, response.text
+        assert response.json == {'message': 'Domain does not exist'}
+
+    def test_track_landing__returns_404_when_campaign_domain_is_disabled(
+        self, client, campaign, write_to_db
+    ):
+        write_to_db(
+            'domain',
+            {
+                'hostname': 'campaign.example.com',
+                'purpose': 'campaign',
+                'campaign_id': campaign['id'],
+                'is_a_record_set': True,
+                'is_disabled': True,
+            },
+        )
+
+        response = client.get(f'/process/{campaign["id"]}', query_string={'clickId': str(uuid4())})
+
+        assert response.status_code == 404, response.text
+        assert response.json == {'message': 'Domain does not exist'}

--- a/apps/api/tests/integration/track/test_process.py
+++ b/apps/api/tests/integration/track/test_process.py
@@ -4,7 +4,6 @@ from uuid import UUID, uuid4
 
 import httpx
 import pytest
-from fixtures.utils import cookie_name
 
 MOBILE_SAFARI_USER_AGENT = (
     'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) '
@@ -29,7 +28,7 @@ def ip2location_mock(environment):
 
 class TestTrackRedirect:
     def test_track_redirect__tracks_discard_when_no_flow_matches(
-        self, client, campaign, write_to_db, read_from_db, ip2location_mock
+        self, client, campaign, domain, write_to_db, read_from_db, ip2location_mock
     ):
         click_id = uuid4()
         write_to_db(
@@ -78,7 +77,7 @@ class TestTrackRedirect:
             'created_at': mock.ANY,
         }
 
-    def test_track_redirect(self, client, campaign, flow, read_from_db, ip2location_mock):
+    def test_track_redirect(self, client, campaign, domain, flow, read_from_db, ip2location_mock):
         click_id = uuid4()
         request_payload = {
             'clickId': str(click_id),
@@ -96,6 +95,15 @@ class TestTrackRedirect:
         response = client.get(f'/process/{campaign["id"]}', query_string=request_payload)
         assert response.status_code == 302, response.text
         assert response.headers['Location'] == flow['redirect_url']  # user gets redirected
+        cookie_row = read_from_db('domain_cookie', filters={'domain_id': domain['id'], 'name': 'flow_id'})
+        assert cookie_row == {
+            'id': mock.ANY,
+            'created_at': mock.ANY,
+            'domain_id': domain['id'],
+            'name': 'flow_id',
+            'opaque_name': mock.ANY,
+        }
+        assert response.headers['Set-Cookie'].startswith(f'{cookie_row["opaque_name"]}={flow["id"]};')
 
         assert ip2location_mock.get_country_short.called
 
@@ -120,7 +128,9 @@ class TestTrackRedirect:
             'tid': request_payload['tid'],
         }
 
-    def test_track_redirect__matches_flow_without_rule(self, client, campaign, write_to_db, ip2location_mock):
+    def test_track_redirect__matches_flow_without_rule(
+        self, client, campaign, domain, write_to_db, ip2location_mock
+    ):
         write_to_db(
             'flow',
             {
@@ -154,13 +164,15 @@ class TestTrackRedirect:
         assert response.status_code == 302, response.text
         assert response.headers['Location'] == fallback_flow['redirect_url']
 
-    def test_track_redirect__missing_click_id(self, client, campaign, flow, ip2location_mock):
+    def test_track_redirect__missing_click_id(self, client, campaign, domain, flow, ip2location_mock):
         response = client.get(f'/process/{campaign["id"]}')
 
         assert response.status_code == 302, response.text
         assert response.headers['Location'] == flow['redirect_url']
 
-    def test_track_redirect__ignores_disabled_and_deleted_flows(self, client, campaign, write_to_db, ip2location_mock):
+    def test_track_redirect__ignores_disabled_and_deleted_flows(
+        self, client, campaign, domain, write_to_db, ip2location_mock
+    ):
         write_to_db(
             'flow',
             {
@@ -207,7 +219,7 @@ class TestTrackRedirect:
         assert response.headers['Location'] == runnable_flow['redirect_url']
 
     def test_track_redirect__returns_no_match_when_only_non_runnable_flows_remain(
-        self, client, campaign, write_to_db, ip2location_mock
+        self, client, campaign, domain, write_to_db, ip2location_mock
     ):
         write_to_db(
             'flow',
@@ -242,7 +254,7 @@ class TestTrackRedirect:
         assert response.text == ''
 
     def test_track_redirect__does_not_track_discard_when_flow_matches(
-        self, client, campaign, flow, read_from_db, ip2location_mock
+        self, client, campaign, domain, flow, read_from_db, ip2location_mock
     ):
         response = client.get(f'/process/{campaign["id"]}', query_string={'clickId': str(uuid4())})
 
@@ -251,7 +263,7 @@ class TestTrackRedirect:
         assert read_from_db('track_discard') is None
 
     def test_track_redirect__generates_click_id_when_missing(
-        self, client, campaign, write_to_db, read_from_db, ip2location_mock
+        self, client, campaign, domain, write_to_db, read_from_db, ip2location_mock
     ):
         write_to_db(
             'flow',
@@ -289,7 +301,7 @@ class TestTrackRedirect:
         assert discard['click_id'] == click['click_id']
 
     def test_track_redirect__uses_deterministic_order_for_runnable_flows(
-        self, client, campaign, write_to_db, ip2location_mock
+        self, client, campaign, domain, write_to_db, ip2location_mock
     ):
         first_inserted_flow = write_to_db(
             'flow',
@@ -347,7 +359,9 @@ class TestTrackLanding:
             httpx.Response(status_code=200, text=landing_page_content)
         )
 
-    def test_track_landing(self, client, campaign, flow, read_from_db, ip2location_mock, landing_render_mock):
+    def test_track_landing(
+        self, client, campaign, domain, flow, read_from_db, ip2location_mock, landing_render_mock
+    ):
         click_id = uuid4()
         request_payload = {
             'clickId': str(click_id),
@@ -391,7 +405,7 @@ class TestTrackLanding:
         }
 
     def test_track_landing__sets_domain_sticky_cookie_on_first_visit(
-        self, client, campaign, environment, write_to_db, ip2location_mock, respx_mock
+        self, client, campaign, domain, environment, write_to_db, read_from_db, ip2location_mock, respx_mock
     ):
         render_flow = write_to_db(
             'flow',
@@ -414,34 +428,30 @@ class TestTrackLanding:
 
         assert response.status_code == 200, response.text
         assert response.text == '<html>Sticky landing</html>'
-
-        hostname = 'campaign.example.com'
-        write_to_db(
-            'domain',
-            {
-                'hostname': hostname,
-                'purpose': 'campaign',
-                'campaign_id': campaign['id'],
-                'is_a_record_set': True,
-                'is_disabled': False,
-            },
-        )
-
+        cookie_row = read_from_db('domain_cookie', filters={'domain_id': domain['id'], 'name': 'flow_id'})
+        assert cookie_row == {
+            'id': mock.ANY,
+            'created_at': mock.ANY,
+            'domain_id': domain['id'],
+            'name': 'flow_id',
+            'opaque_name': mock.ANY,
+        }
         cookie_header = response.headers['Set-Cookie']
-        assert cookie_name(hostname) in cookie_header
+        assert cookie_row['opaque_name'] in cookie_header
         assert f'={render_flow["id"]}' in cookie_header
         assert 'HttpOnly' in cookie_header
         assert 'Max-Age=31536000' in cookie_header
         assert 'Path=/' in cookie_header
 
-    def test_track_landing__returns_404_when_campaign_domain_is_missing(self, client, campaign):
+    def test_track_landing__returns_404_when_campaign_domain_is_missing(self, client, campaign, read_from_db):
         response = client.get(f'/process/{campaign["id"]}', query_string={'clickId': str(uuid4())})
 
         assert response.status_code == 404, response.text
         assert response.json == {'message': 'Domain does not exist'}
+        assert read_from_db('track_click') is None
 
     def test_track_landing__returns_404_when_campaign_domain_is_disabled(
-        self, client, campaign, write_to_db
+        self, client, campaign, read_from_db, write_to_db
     ):
         write_to_db(
             'domain',
@@ -458,3 +468,4 @@ class TestTrackLanding:
 
         assert response.status_code == 404, response.text
         assert response.json == {'message': 'Domain does not exist'}
+        assert read_from_db('track_click') is None

--- a/apps/api/tests/integration/track/test_process.py
+++ b/apps/api/tests/integration/track/test_process.py
@@ -128,9 +128,7 @@ class TestTrackRedirect:
             'tid': request_payload['tid'],
         }
 
-    def test_track_redirect__matches_flow_without_rule(
-        self, client, campaign, domain, write_to_db, ip2location_mock
-    ):
+    def test_track_redirect__matches_flow_without_rule(self, client, campaign, domain, write_to_db, ip2location_mock):
         write_to_db(
             'flow',
             {
@@ -359,9 +357,7 @@ class TestTrackLanding:
             httpx.Response(status_code=200, text=landing_page_content)
         )
 
-    def test_track_landing(
-        self, client, campaign, domain, flow, read_from_db, ip2location_mock, landing_render_mock
-    ):
+    def test_track_landing(self, client, campaign, domain, flow, read_from_db, ip2location_mock, landing_render_mock):
         click_id = uuid4()
         request_payload = {
             'clickId': str(click_id),

--- a/infra/installer/install.sh
+++ b/infra/installer/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-BANGI_RELEASE_TAG="0.0.1a22"
+BANGI_RELEASE_TAG="0.0.1a23"
 BANGI_GITHUB_OWNER="devalentino"
 BANGI_GITHUB_REPO="bangi"
 BANGI_RAW_BASE_URL="https://raw.githubusercontent.com/${BANGI_GITHUB_OWNER}/${BANGI_GITHUB_REPO}/${BANGI_RELEASE_TAG}"

--- a/infra/installer/templates/compose.prod.yml
+++ b/infra/installer/templates/compose.prod.yml
@@ -1,6 +1,6 @@
 services:
   web:
-    image: ghcr.io/devalentino/bangi-web:0.0.1a22
+    image: ghcr.io/devalentino/bangi-web:0.0.1a23
     restart: always
     env_file:
       - /opt/bangi/shared/env/.env
@@ -10,7 +10,7 @@ services:
       - bangi
 
   api:
-    image: ghcr.io/devalentino/bangi-api:0.0.1a22
+    image: ghcr.io/devalentino/bangi-api:0.0.1a23
     restart: always
     env_file:
       - /opt/bangi/shared/env/.env

--- a/infra/installer/templates/compose.prod.yml
+++ b/infra/installer/templates/compose.prod.yml
@@ -73,6 +73,8 @@ services:
     mem_reservation: 32m
     env_file:
       - /opt/bangi/shared/env/.env
+    ports:
+      - '127.0.0.1:8081:80'
     volumes:
       - /opt/bangi/shared/landings:/var/www/html/landings
     networks:


### PR DESCRIPTION
## Summary
- Introduces a domain-scoped opaque cookie registry and lazy generation for tracker sticky cookies.
- Reworks `/process` to resolve the campaign domain first, reuse the stored opaque cookie name, and set the sticky cookie from the selected flow.
- Removes `cookieName` from domain API responses and updates nginx config/tests to consume the registry-backed cookie name.
- Adds the production compose port mapping needed for the render flow path.

## Scope
- Included: domain cookie table and service, tracker cookie handling, domain response schema cleanup, nginx config updates, production compose port exposure, and test updates.
- Not included: new public APIs for managing cookie names, additional cookie families beyond the flow sticky cookie, or changes to flow selection semantics beyond passing the sticky cookie value through.

## Risks
- Low to moderate risk: the first request to a campaign domain lazily creates the cookie mapping, so concurrent requests rely on the DB uniqueness retry path. Cookie names are short random tokens and are persisted per domain.

## Links
- Jira: KAN-39
- Spec: TBD
