### PR TITLE
KAN-44: feat: domain certificate tracking and release bump

### DIFF
--- a/apps/api/migrations/011_domain_certificate.py
+++ b/apps/api/migrations/011_domain_certificate.py
@@ -1,0 +1,51 @@
+"""Peewee migrations -- 011_domain_certificate.py."""
+
+from contextlib import suppress
+
+import peewee as pw
+from peewee_migrate import Migrator
+
+
+with suppress(ImportError):
+    import playhouse.postgres_ext as pw_pext
+
+
+DOMAIN_CERTIFICATE_TABLE = 'domain_certificate'
+
+
+def migrate(migrator: Migrator, database: pw.Database, *, fake=False):
+    """Write your migrations here."""
+
+    @migrator.create_model
+    class DomainCertificate(pw.Model):
+        id = pw.AutoField()
+        created_at = pw.TimestampField(null=True)
+        domain = pw.ForeignKeyField(
+            column_name='domain_id',
+            field='id',
+            model=migrator.orm['domain'],
+            on_delete='CASCADE',
+            unique=True,
+        )
+        status = pw.CharField(max_length=32)
+        ca = pw.CharField(max_length=32)
+        validation_method = pw.CharField(max_length=32)
+        certificate_path = pw.CharField(max_length=512, null=True)
+        private_key_path = pw.CharField(max_length=512, null=True)
+        issued_at = pw.TimestampField(null=True)
+        expires_at = pw.TimestampField(null=True)
+        last_attempted_at = pw.TimestampField(null=True)
+        last_issued_at = pw.TimestampField(null=True)
+        last_renewed_at = pw.TimestampField(null=True)
+        next_retry_at = pw.TimestampField(null=True)
+        failure_count = pw.IntegerField(default=0)
+        failure_reason = pw.TextField(null=True)
+
+        class Meta:
+            table_name = DOMAIN_CERTIFICATE_TABLE
+
+
+def rollback(migrator: Migrator, database: pw.Database, *, fake=False):
+    """Write your rollback migrations here."""
+
+    migrator.remove_model(DOMAIN_CERTIFICATE_TABLE)

--- a/apps/api/src/container.py
+++ b/apps/api/src/container.py
@@ -12,7 +12,13 @@ from src.core.entities import database_proxy
 from src.core.repositories import CampaignRepository
 from src.core.services import CampaignService, ClientService, FlowService, Ip2LocationLocator
 from src.core.supervisor import WorkerContext, WorkerSupervisor
-from src.domains.services import DomainCookieService, DomainService, HostCommandExecutorService, NginxService
+from src.domains.services import (
+    CertificateService,
+    DomainCookieService,
+    DomainService,
+    HostCommandExecutorService,
+    NginxService,
+)
 from src.facebook_pacs.services import AdCabinetService as FacebookPacsAdCabinetService
 from src.facebook_pacs.services import BusinessPageService as FacebookPacsBusinessPageService
 from src.facebook_pacs.services import BusinessPortfolioService as FacebookPacsBusinessPortfolioService
@@ -54,6 +60,8 @@ container = create_sync_container(
         'BANGI_HOST_OPS_SSH_HOST': _get_env('BANGI_HOST_OPS_SSH_HOST', str, 'host.docker.internal'),
         'BANGI_HOST_OPS_SSH_KEY_PATH': _get_env('BANGI_HOST_OPS_SSH_KEY_PATH', str, ''),
         'BANGI_HOST_OPS_SSH_KNOWN_HOSTS_PATH': _get_env('BANGI_HOST_OPS_SSH_KNOWN_HOSTS_PATH', str, ''),
+        'BANGI_CERTIFICATE_MAX_BACKOFF_SECONDS': _get_env('BANGI_CERTIFICATE_MAX_BACKOFF_SECONDS', int, 86400),
+        'BANGI_CERTIFICATE_RETRY_JITTER_SECONDS': _get_env('BANGI_CERTIFICATE_RETRY_JITTER_SECONDS', int, 120),
         'DISK_UTILIZATION_STALE_AFTER_SECONDS': _get_env('DISK_UTILIZATION_STALE_AFTER_SECONDS', int, 2 * 60 * 60),
         'DISK_UTILIZATION_WARNING_PERCENT': _get_env('DISK_UTILIZATION_WARNING_PERCENT', int, 70),
         'DISK_UTILIZATION_CRITICAL_PERCENT': _get_env('DISK_UTILIZATION_CRITICAL_PERCENT', int, 80),
@@ -69,6 +77,7 @@ container = create_sync_container(
         CampaignRepository,
         CampaignService,
         ClientService,
+        CertificateService,
         DomainCookieService,
         DomainService,
         HostCommandExecutorService,

--- a/apps/api/src/domains/entities.py
+++ b/apps/api/src/domains/entities.py
@@ -1,6 +1,7 @@
-from peewee import BooleanField, CharField, ForeignKeyField
+from peewee import BooleanField, CharField, ForeignKeyField, IntegerField, TextField
 
 from src.core.entities import Campaign, Entity
+from src.core.peewee import UTCTimestampField
 
 
 class Domain(Entity):
@@ -22,3 +23,23 @@ class DomainCookie(Entity):
     class Meta:
         table_name = 'domain_cookie'
         indexes = ((('domain', 'name'), True), (('domain', 'opaque_name'), True))
+
+
+class DomainCertificate(Entity):
+    domain = ForeignKeyField(Domain, on_delete='CASCADE', unique=True)
+    status = CharField(max_length=32)
+    ca = CharField(max_length=32)
+    validation_method = CharField(max_length=32)
+    certificate_path = CharField(max_length=512, null=True)
+    private_key_path = CharField(max_length=512, null=True)
+    issued_at = UTCTimestampField(null=True, utc=True)
+    expires_at = UTCTimestampField(null=True, utc=True)
+    last_attempted_at = UTCTimestampField(null=True, utc=True)
+    last_issued_at = UTCTimestampField(null=True, utc=True)
+    last_renewed_at = UTCTimestampField(null=True, utc=True)
+    next_retry_at = UTCTimestampField(null=True, utc=True)
+    failure_count = IntegerField(default=0)
+    failure_reason = TextField(null=True)
+
+    class Meta:
+        table_name = 'domain_certificate'

--- a/apps/api/src/domains/enums.py
+++ b/apps/api/src/domains/enums.py
@@ -18,3 +18,18 @@ class DomainSortBy(str, Enum):
     campaignId = 'campaignId'
     isARecordSet = 'isARecordSet'
     isDisabled = 'isDisabled'
+
+
+class DomainCertificateStatus(str, Enum):
+    pending = 'pending'
+    active = 'active'
+    failed = 'failed'
+    expired = 'expired'
+
+
+class DomainCertificateCa(str, Enum):
+    letsencrypt = 'letsencrypt'
+
+
+class DomainCertificateValidationMethod(str, Enum):
+    http_01_webroot = 'http-01-webroot'

--- a/apps/api/src/domains/exceptions.py
+++ b/apps/api/src/domains/exceptions.py
@@ -10,6 +10,10 @@ class DomainDoesNotExistError(DoesNotExistError):
     message = 'Domain does not exist'
 
 
+class DomainCertificateDoesNotExistError(DoesNotExistError):
+    message = 'Domain certificate does not exist'
+
+
 class CampaignAlreadyBoundError(ApplicationError):
     http_status_code = 400
     message = 'Campaign is already attached to a domain'

--- a/apps/api/src/domains/services.py
+++ b/apps/api/src/domains/services.py
@@ -1,9 +1,11 @@
 import logging
+import random
 import secrets
 import string
 import subprocess
 import time
 from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path
 from typing import Annotated, Protocol
 from uuid import uuid4
@@ -16,12 +18,19 @@ from wireup import Inject, injectable
 from src.core.entities import Campaign
 from src.core.enums import SortOrder
 from src.core.exceptions import CampaignDoesNotExistError
-from src.domains.entities import Domain, DomainCookie
-from src.domains.enums import DomainCookieName, DomainPurpose
+from src.domains.entities import Domain, DomainCertificate, DomainCookie
+from src.domains.enums import (
+    DomainCertificateCa,
+    DomainCertificateStatus,
+    DomainCertificateValidationMethod,
+    DomainCookieName,
+    DomainPurpose,
+)
 from src.domains.exceptions import (
     CampaignAlreadyBoundError,
     DashboardDomainCannotAttachCampaignError,
     DomainAlreadyExistsError,
+    DomainCertificateDoesNotExistError,
     DomainDoesNotExistError,
 )
 from src.health.services import HealthService
@@ -35,6 +44,18 @@ class WebserverPublishResult:
     validation_error: str | None
     sites_available_files: list[str]
     sites_enabled_refs: list[str]
+
+
+@dataclass(slots=True)
+class AcmeExecutionSnapshot:
+    status: str
+    hostname: str
+    certificate_path: str | None
+    private_key_path: str | None
+    issued_at: datetime | None
+    expires_at: datetime | None
+    error: str | None
+    is_renewal: bool = False
 
 
 @injectable
@@ -97,6 +118,70 @@ class DnsService:
             return False
 
         return any(answer.address == public_host_ip for answer in answers)
+
+
+@injectable
+class CertificateService:
+    def __init__(
+        self,
+        certificate_max_backoff_seconds: Annotated[int, Inject(config='BANGI_CERTIFICATE_MAX_BACKOFF_SECONDS')],
+        certificate_retry_jitter_seconds: Annotated[int, Inject(config='BANGI_CERTIFICATE_RETRY_JITTER_SECONDS')],
+    ):
+        self.certificate_max_backoff_seconds = certificate_max_backoff_seconds
+        self.certificate_retry_jitter_seconds = certificate_retry_jitter_seconds
+
+    def get(self, domain_id: int) -> DomainCertificate:
+        try:
+            return DomainCertificate.get(DomainCertificate.domain == domain_id)
+        except DomainCertificate.DoesNotExist as exc:
+            raise DomainCertificateDoesNotExistError() from exc
+
+    def update_status(self, domain_id: int, snapshot: AcmeExecutionSnapshot) -> DomainCertificate:
+        now = int(time.time())
+        certificate = DomainCertificate.get_or_none(DomainCertificate.domain == domain_id)
+        if certificate is None:
+            certificate = DomainCertificate(
+                domain=domain_id,
+                ca=DomainCertificateCa.letsencrypt.value,
+                validation_method=DomainCertificateValidationMethod.http_01_webroot.value,
+                failure_count=0,
+            )
+
+        status = DomainCertificateStatus(snapshot.status)
+        certificate.status = status.value
+        certificate.last_attempted_at = now
+
+        if status == DomainCertificateStatus.active:
+            certificate.certificate_path = snapshot.certificate_path
+            certificate.private_key_path = snapshot.private_key_path
+            certificate.issued_at = snapshot.issued_at
+            certificate.expires_at = snapshot.expires_at
+            certificate.failure_count = 0
+            certificate.failure_reason = None
+            certificate.next_retry_at = None
+            if snapshot.is_renewal:
+                certificate.last_renewed_at = now
+            else:
+                certificate.last_issued_at = now
+        elif status == DomainCertificateStatus.failed:
+            if certificate.id is None:
+                certificate.certificate_path = None
+                certificate.private_key_path = None
+            certificate.failure_count = certificate.failure_count + 1
+            certificate.failure_reason = snapshot.error
+            certificate.next_retry_at = now + self._retry_delay_seconds(certificate.failure_count)
+        elif status == DomainCertificateStatus.pending:
+            certificate.failure_reason = None
+        elif status == DomainCertificateStatus.expired:
+            certificate.next_retry_at = now
+
+        certificate.save()
+        return certificate
+
+    def _retry_delay_seconds(self, failure_count: int) -> int:
+        retry_delay_seconds = min(2**failure_count * 300, self.certificate_max_backoff_seconds)
+        retry_jitter_seconds = random.randint(0, self.certificate_retry_jitter_seconds)
+        return retry_delay_seconds + retry_jitter_seconds
 
 
 @injectable

--- a/apps/api/tests/integration/domains/test_domains.py
+++ b/apps/api/tests/integration/domains/test_domains.py
@@ -35,6 +35,7 @@ class TestDomains:
             'is_a_record_set': None,
             'is_disabled': False,
         }
+        assert read_from_db('domain_certificate') is None
 
     def test_list_domains_returns_campaign_and_dashboard_domains(self, client, authorization, campaign, write_to_db):
         for index in range(19):
@@ -250,6 +251,38 @@ class TestDomains:
 
         assert old_enabled_link.exists() is False
         assert new_enabled_link.is_symlink()
+
+    def test_update_domain_to_disabled_keeps_certificate_metadata_unchanged(
+        self, client, authorization, domain, read_from_db, write_to_db
+    ):
+        certificate = write_to_db(
+            'domain_certificate',
+            {
+                'domain_id': domain['id'],
+                'status': 'active',
+                'ca': 'letsencrypt',
+                'validation_method': 'http-01-webroot',
+                'certificate_path': '/etc/nginx/bangi/certs/campaign.example.com/fullchain.pem',
+                'private_key_path': '/etc/nginx/bangi/certs/campaign.example.com/privkey.pem',
+                'issued_at': 1778587200,
+                'expires_at': 1786363200,
+                'last_attempted_at': 1778587200,
+                'last_issued_at': 1778587200,
+                'last_renewed_at': None,
+                'next_retry_at': None,
+                'failure_count': 0,
+                'failure_reason': None,
+            },
+        )
+
+        response = client.patch(
+            f'/api/v2/domains/{domain["id"]}',
+            headers={'Authorization': authorization},
+            json={'isDisabled': True},
+        )
+
+        assert response.status_code == 200, response.text
+        assert read_from_db('domain_certificate', filters={'id': certificate['id']}) == certificate
 
     def test_update_domain_attaches_campaign(self, client, authorization, campaign, write_to_db, read_from_db):
         domain = write_to_db(

--- a/infra/installer/install.sh
+++ b/infra/installer/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-BANGI_RELEASE_TAG="0.0.1a26"
+BANGI_RELEASE_TAG="0.0.1a27"
 BANGI_GITHUB_OWNER="devalentino"
 BANGI_GITHUB_REPO="bangi"
 BANGI_RAW_BASE_URL="https://raw.githubusercontent.com/${BANGI_GITHUB_OWNER}/${BANGI_GITHUB_REPO}/${BANGI_RELEASE_TAG}"

--- a/infra/installer/templates/compose.prod.yml
+++ b/infra/installer/templates/compose.prod.yml
@@ -1,6 +1,6 @@
 services:
   web:
-    image: ghcr.io/devalentino/bangi-web:0.0.1a26
+    image: ghcr.io/devalentino/bangi-web:0.0.1a27
     restart: always
     env_file:
       - /opt/bangi/shared/env/.env
@@ -10,7 +10,7 @@ services:
       - bangi
 
   api:
-    image: ghcr.io/devalentino/bangi-api:0.0.1a26
+    image: ghcr.io/devalentino/bangi-api:0.0.1a27
     restart: always
     env_file:
       - /opt/bangi/shared/env/.env


### PR DESCRIPTION
## Summary
- Adds domain certificate persistence and status tracking for ACME/Let's Encrypt flows.
- Preserves certificate metadata when a domain is disabled.

## Scope
- Included:
  - New `domain_certificate` migration and entity model.
  - Certificate service logic for create/update/status backoff handling.
  - Integration coverage for certificate metadata remaining unchanged when disabling a domain.
  - Release tag and image version bump in installer assets.
- Not included:
  - ACME orchestration or renewal job execution.
  - UI or API endpoints for managing certificates directly.
  - Support for certificate providers beyond Let's Encrypt.

## Risks
- Certificate retry timing and timestamp persistence need watchful validation, especially around failure backoff and renewal timestamps.
- The installer/image bump is release-sensitive; a version mismatch would deploy the wrong artifact set.

## Links
- Jira: KAN-44
- Spec: TBD
