### PR TITLE
KAN-45: feat: managed HTTPS ACME parsing and release bump

### DIFF
--- a/apps/api/src/container.py
+++ b/apps/api/src/container.py
@@ -13,6 +13,7 @@ from src.core.repositories import CampaignRepository
 from src.core.services import CampaignService, ClientService, FlowService, Ip2LocationLocator
 from src.core.supervisor import WorkerContext, WorkerSupervisor
 from src.domains.services import (
+    AcmeService,
     CertificateService,
     DomainCookieService,
     DomainService,
@@ -77,6 +78,7 @@ container = create_sync_container(
         CampaignRepository,
         CampaignService,
         ClientService,
+        AcmeService,
         CertificateService,
         DomainCookieService,
         DomainService,

--- a/apps/api/src/domains/routes.py
+++ b/apps/api/src/domains/routes.py
@@ -4,21 +4,16 @@ from flask.views import MethodView
 from src.auth import auth
 from src.container import container
 from src.core.blueprint import Blueprint
+from src.domains.exceptions import DomainCertificateDoesNotExistError
 from src.domains.schemas import (
+    DomainCertificateResponseSchema,
     DomainCreateRequestSchema,
     DomainListRequestSchema,
     DomainListResponseSchema,
     DomainResponseSchema,
     DomainUpdateRequestSchema,
 )
-from src.domains.services import DomainService
-from src.health.services import HealthService
-
-
-def _validation_failed(domain):
-    snapshot = container.get(HealthService).latest_nginx_validation_snapshot()
-    return bool(snapshot is not None and snapshot.validation_status == 'failed' and snapshot.domain_id == domain.id)
-
+from src.domains.services import CertificateService, DomainService
 
 blueprint = Blueprint('domains', __name__, description='Domains')
 
@@ -36,22 +31,9 @@ class Domains(MethodView):
             humps.decamelize(parameters_payload['sortBy'].value),
             parameters_payload['sortOrder'],
         )
+
         return {
-            'content': [
-                humps.camelize(
-                    {
-                        'id': domain.id,
-                        'hostname': domain.hostname,
-                        'purpose': domain.purpose,
-                        'campaign_id': domain.campaign_id,
-                        'campaign_name': None if domain.campaign_id is None else domain.campaign.name,
-                        'validation_failed': False,
-                        'is_a_record_set': (None if domain.is_a_record_set is None else bool(domain.is_a_record_set)),
-                        'is_disabled': bool(domain.is_disabled),
-                    }
-                )
-                for domain in domains
-            ],
+            'content': [humps.camelize(domain) for domain in domains],
             'pagination': parameters_payload | {'total': domain_service.count()},
         }
 
@@ -68,9 +50,9 @@ class Domains(MethodView):
                 'purpose': domain.purpose,
                 'campaign_id': domain.campaign_id,
                 'campaign_name': None if domain.campaign_id is None else domain.campaign.name,
-                'validation_failed': False,
                 'is_a_record_set': None if domain.is_a_record_set is None else bool(domain.is_a_record_set),
                 'is_disabled': bool(domain.is_disabled),
+                'certificate_status': None,
             }
         )
 
@@ -81,7 +63,14 @@ class Domain(MethodView):
     @auth.login_required
     def get(self, domainId):
         domain_service = container.get(DomainService)
+        certificate_service = container.get(CertificateService)
         domain = domain_service.get(domainId)
+
+        try:
+            certificate_status = certificate_service.get(domain.id).status
+        except DomainCertificateDoesNotExistError:
+            certificate_status = None
+
         return humps.camelize(
             {
                 'id': domain.id,
@@ -89,9 +78,9 @@ class Domain(MethodView):
                 'purpose': domain.purpose,
                 'campaign_id': domain.campaign_id,
                 'campaign_name': None if domain.campaign_id is None else domain.campaign.name,
-                'validation_failed': _validation_failed(domain),
                 'is_a_record_set': None if domain.is_a_record_set is None else bool(domain.is_a_record_set),
                 'is_disabled': bool(domain.is_disabled),
+                'certificate_status': certificate_status,
             }
         )
 
@@ -100,6 +89,8 @@ class Domain(MethodView):
     @auth.login_required
     def patch(self, payload, domainId):
         domain_service = container.get(DomainService)
+        certificate_service = container.get(CertificateService)
+
         domain = domain_service.update(
             domainId,
             hostname=payload.get('hostname'),
@@ -107,6 +98,12 @@ class Domain(MethodView):
             campaign_id=payload.get('campaignId'),
             is_disabled=payload.get('isDisabled'),
         )
+
+        try:
+            certificate_status = certificate_service.get(domain.id).status
+        except DomainCertificateDoesNotExistError:
+            certificate_status = None
+
         return humps.camelize(
             {
                 'id': domain.id,
@@ -114,8 +111,39 @@ class Domain(MethodView):
                 'purpose': domain.purpose,
                 'campaign_id': domain.campaign_id,
                 'campaign_name': None if domain.campaign_id is None else domain.campaign.name,
-                'validation_failed': _validation_failed(domain),
                 'is_a_record_set': None if domain.is_a_record_set is None else bool(domain.is_a_record_set),
                 'is_disabled': bool(domain.is_disabled),
+                'certificate_status': certificate_status,
+            }
+        )
+
+
+@blueprint.route('/<int:domainId>/certificate')
+class DomainCertificate(MethodView):
+    @blueprint.response(200, DomainCertificateResponseSchema)
+    @auth.login_required
+    def get(self, domainId):
+        certificate_service = container.get(CertificateService)
+
+        certificate = certificate_service.get(domainId)
+        return humps.camelize(
+            {
+                'status': certificate.status,
+                'ca': certificate.ca,
+                'validation_method': certificate.validation_method,
+                'expires_at': None if certificate.expires_at is None else int(certificate.expires_at.timestamp()),
+                'last_attempted_at': (
+                    None if certificate.last_attempted_at is None else int(certificate.last_attempted_at.timestamp())
+                ),
+                'last_issued_at': (
+                    None if certificate.last_issued_at is None else int(certificate.last_issued_at.timestamp())
+                ),
+                'last_renewed_at': (
+                    None if certificate.last_renewed_at is None else int(certificate.last_renewed_at.timestamp())
+                ),
+                'next_retry_at': (
+                    None if certificate.next_retry_at is None else int(certificate.next_retry_at.timestamp())
+                ),
+                'failure_reason': certificate.failure_reason,
             }
         )

--- a/apps/api/src/domains/schemas.py
+++ b/apps/api/src/domains/schemas.py
@@ -66,9 +66,21 @@ class DomainResponseSchema(Schema):
     purpose = fields.String(required=True)
     campaignId = fields.Integer(allow_none=True)
     campaignName = fields.String(allow_none=True)
-    validationFailed = fields.Boolean(required=True)
     isARecordSet = fields.Boolean(allow_none=True)
     isDisabled = fields.Boolean(required=True)
+    certificateStatus = fields.String(allow_none=True)
+
+
+class DomainCertificateResponseSchema(Schema):
+    status = fields.String(required=True)
+    ca = fields.String(required=True)
+    validationMethod = fields.String(required=True)
+    expiresAt = fields.Integer(allow_none=True)
+    lastAttemptedAt = fields.Integer(allow_none=True)
+    lastIssuedAt = fields.Integer(allow_none=True)
+    lastRenewedAt = fields.Integer(allow_none=True)
+    nextRetryAt = fields.Integer(allow_none=True)
+    failureReason = fields.String(allow_none=True)
 
 
 class DomainListResponseSchema(Schema):

--- a/apps/api/src/domains/services.py
+++ b/apps/api/src/domains/services.py
@@ -1,6 +1,6 @@
 import logging
-import re
 import random
+import re
 import secrets
 import shlex
 import string
@@ -410,9 +410,7 @@ class AcmeService:
     _CERTIFICATE_PATH_PATTERNS = (
         re.compile(r'(?:Your cert(?:ificate)? is in|The cert is in|The full-?chain cert is in):\s*(\S+)'),
     )
-    _PRIVATE_KEY_PATH_PATTERNS = (
-        re.compile(r'(?:Your cert key is in|The domain key is here|The key is in):\s*(\S+)'),
-    )
+    _PRIVATE_KEY_PATH_PATTERNS = (re.compile(r'(?:Your cert key is in|The domain key is here|The key is in):\s*(\S+)'),)
 
     def __init__(self, host_command_executor_service: HostCommandExecutorService):
         self.host_command_executor_service = host_command_executor_service

--- a/apps/api/src/domains/services.py
+++ b/apps/api/src/domains/services.py
@@ -207,14 +207,25 @@ class DomainService:
         if sort_order == SortOrder.desc:
             order_by = order_by.desc()
 
-        return [
-            domain
-            for domain in Domain.select(Domain, Campaign)
+        return (
+            Domain.select(
+                Domain.id.alias('id'),
+                Domain.hostname.alias('hostname'),
+                Domain.purpose.alias('purpose'),
+                Domain.campaign_id.alias('campaign_id'),
+                Campaign.name.alias('campaign_name'),
+                Domain.is_a_record_set.alias('is_a_record_set'),
+                Domain.is_disabled.alias('is_disabled'),
+                DomainCertificate.status.alias('certificate_status'),
+            )
             .join(Campaign, JOIN.LEFT_OUTER)
+            .switch(Domain)
+            .join(DomainCertificate, JOIN.LEFT_OUTER)
             .order_by(order_by, Domain.id.asc())
             .limit(page_size)
             .offset((page - 1) * page_size)
-        ]
+            .dicts()
+        )
 
     def count(self):
         return Domain.select(fn.count(Domain.id)).scalar()

--- a/apps/api/src/domains/services.py
+++ b/apps/api/src/domains/services.py
@@ -1,11 +1,13 @@
 import logging
+import re
 import random
 import secrets
+import shlex
 import string
 import subprocess
 import time
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Annotated, Protocol
 from uuid import uuid4
@@ -358,7 +360,7 @@ class HostCommandExecutorService:
         self.host_ops_ssh_key_path = host_ops_ssh_key_path
         self.host_ops_ssh_known_hosts_path = host_ops_ssh_known_hosts_path
 
-    def run(self, command: str) -> None:
+    def run(self, command: str) -> str:
         if not all(
             [
                 self.host_ops_ssh_user,
@@ -399,6 +401,144 @@ class HostCommandExecutorService:
                 },
             )
             raise HostCommandExecutionError(output or f'Host operation failed: {command}')
+
+        return output
+
+
+@injectable
+class AcmeService:
+    _CERTIFICATE_PATH_PATTERNS = (
+        re.compile(r'(?:Your cert(?:ificate)? is in|The cert is in|The full-?chain cert is in):\s*(\S+)'),
+    )
+    _PRIVATE_KEY_PATH_PATTERNS = (
+        re.compile(r'(?:Your cert key is in|The domain key is here|The key is in):\s*(\S+)'),
+    )
+
+    def __init__(self, host_command_executor_service: HostCommandExecutorService):
+        self.host_command_executor_service = host_command_executor_service
+
+    def issue(self, hostname: str) -> AcmeExecutionSnapshot:
+        return self._run_wrapper('acme-issue-certificate', hostname, is_renewal=False)
+
+    def renew(self, hostname: str) -> AcmeExecutionSnapshot:
+        return self._run_wrapper('acme-renew-certificate', hostname, is_renewal=True)
+
+    def _run_wrapper(self, wrapper_command: str, hostname: str, is_renewal: bool) -> AcmeExecutionSnapshot:
+        command = f'{wrapper_command} {shlex.quote(hostname)}'
+        try:
+            output = self.host_command_executor_service.run(command)
+        except HostCommandExecutionError as exc:
+            return self._failed_snapshot(
+                hostname,
+                str(exc),
+                is_renewal,
+                command=command,
+                output=str(exc),
+                detail=str(exc),
+            )
+
+        certificate_path = self._extract_first_match(output, self._CERTIFICATE_PATH_PATTERNS)
+        private_key_path = self._extract_first_match(output, self._PRIVATE_KEY_PATH_PATTERNS)
+        if certificate_path is None or private_key_path is None:
+            return self._failed_snapshot(
+                hostname,
+                'Invalid ACME wrapper output: missing certificate paths',
+                is_renewal,
+                command=command,
+                output=output,
+            )
+
+        try:
+            issued_at, expires_at = self._load_certificate_timestamps(certificate_path)
+        except (HostCommandExecutionError, ValueError) as exc:
+            return self._failed_snapshot(
+                hostname,
+                str(exc),
+                is_renewal,
+                command=command,
+                output=output,
+                detail=str(exc),
+            )
+
+        if expires_at is None:
+            return self._failed_snapshot(
+                hostname,
+                'Invalid ACME wrapper output: missing certificate expiration',
+                is_renewal,
+                command=command,
+                output=output,
+            )
+
+        return AcmeExecutionSnapshot(
+            status=DomainCertificateStatus.active.value,
+            hostname=hostname,
+            certificate_path=certificate_path,
+            private_key_path=private_key_path,
+            issued_at=issued_at,
+            expires_at=expires_at,
+            error=None,
+            is_renewal=is_renewal,
+        )
+
+    @classmethod
+    def _extract_first_match(cls, output: str, patterns: tuple[re.Pattern[str], ...]) -> str | None:
+        for line in output.splitlines():
+            stripped_line = line.strip()
+            for pattern in patterns:
+                match = pattern.search(stripped_line)
+                if match is not None:
+                    return match.group(1)
+        return None
+
+    def _load_certificate_timestamps(self, certificate_path: str) -> tuple[datetime | None, datetime | None]:
+        certificate_info_command = f"openssl x509 -startdate -enddate -noout -in {shlex.quote(certificate_path)}"
+        output = self.host_command_executor_service.run(certificate_info_command)
+
+        issued_at = None
+        expires_at = None
+        for line in output.splitlines():
+            stripped_line = line.strip()
+            if stripped_line.startswith('notBefore='):
+                issued_at = self._parse_openssl_timestamp(stripped_line.removeprefix('notBefore='))
+            elif stripped_line.startswith('notAfter='):
+                expires_at = self._parse_openssl_timestamp(stripped_line.removeprefix('notAfter='))
+        return issued_at, expires_at
+
+    @staticmethod
+    def _parse_openssl_timestamp(raw_value: str) -> datetime:
+        parsed_value = datetime.strptime(raw_value, '%b %d %H:%M:%S %Y %Z')
+        return parsed_value.replace(tzinfo=timezone.utc)
+
+    def _failed_snapshot(
+        self,
+        hostname: str,
+        reason: str,
+        is_renewal: bool,
+        command: str | None = None,
+        output: str | None = None,
+        detail: str | None = None,
+    ) -> AcmeExecutionSnapshot:
+        logger.error(
+            'ACME wrapper failed',
+            extra={
+                'hostname': hostname,
+                'command': command,
+                'output': output,
+                'failure_detail': detail,
+                'failure_reason': reason,
+                'is_renewal': is_renewal,
+            },
+        )
+        return AcmeExecutionSnapshot(
+            status=DomainCertificateStatus.failed.value,
+            hostname=hostname,
+            certificate_path=None,
+            private_key_path=None,
+            issued_at=None,
+            expires_at=None,
+            error=output or reason,
+            is_renewal=is_renewal,
+        )
 
 
 @injectable(as_type=WebserverService)

--- a/apps/api/tests/integration/domains/test_domains.py
+++ b/apps/api/tests/integration/domains/test_domains.py
@@ -338,7 +338,7 @@ class TestDomains:
         response = client.patch(
             f'/api/v2/domains/{domain["id"]}',
             headers={'Authorization': authorization},
-            json={'isDisabled': True},
+            json={'isDisabled': True, 'campaignId': domain['campaign_id']},
         )
 
         assert response.status_code == 200, response.text

--- a/apps/api/tests/integration/domains/test_domains.py
+++ b/apps/api/tests/integration/domains/test_domains.py
@@ -20,9 +20,9 @@ class TestDomains:
             'purpose': 'campaign',
             'campaignId': None,
             'campaignName': None,
-            'validationFailed': False,
             'isARecordSet': None,
             'isDisabled': False,
+            'certificateStatus': None,
         }
 
         domain = read_from_db('domain')
@@ -59,6 +59,25 @@ class TestDomains:
                 'is_disabled': False,
             },
         )
+        campaign_domain_certificate = write_to_db(
+            'domain_certificate',
+            {
+                'domain_id': campaign_domain['id'],
+                'status': 'active',
+                'ca': 'letsencrypt',
+                'validation_method': 'http-01-webroot',
+                'certificate_path': '/etc/nginx/bangi/certs/example.com/fullchain.pem',
+                'private_key_path': '/etc/nginx/bangi/certs/example.com/privkey.pem',
+                'issued_at': 1778587200,
+                'expires_at': 1786363200,
+                'last_attempted_at': 1778587200,
+                'last_issued_at': 1778587200,
+                'last_renewed_at': None,
+                'next_retry_at': None,
+                'failure_count': 0,
+                'failure_reason': None,
+            },
+        )
         dashboard_domain = write_to_db(
             'domain',
             {
@@ -80,9 +99,9 @@ class TestDomains:
             'purpose': 'campaign',
             'campaignId': None,
             'campaignName': None,
-            'validationFailed': False,
             'isARecordSet': None,
             'isDisabled': False,
+            'certificateStatus': None,
         }
         assert response.json['content'][-1] == {
             'id': mock.ANY,
@@ -90,9 +109,9 @@ class TestDomains:
             'purpose': campaign_domain['purpose'],
             'campaignId': campaign_domain['campaign_id'],
             'campaignName': campaign['name'],
-            'validationFailed': False,
             'isARecordSet': campaign_domain['is_a_record_set'],
             'isDisabled': campaign_domain['is_disabled'],
+            'certificateStatus': campaign_domain_certificate['status'],
         }
         assert dashboard_domain['hostname'] not in {item['hostname'] for item in response.json['content']}
         assert response.json['pagination'] == {
@@ -150,9 +169,9 @@ class TestDomains:
                     'purpose': third['purpose'],
                     'campaignId': third['campaign_id'],
                     'campaignName': None,
-                    'validationFailed': False,
                     'isARecordSet': third['is_a_record_set'],
                     'isDisabled': third['is_disabled'],
+                    'certificateStatus': None,
                 },
                 {
                     'id': first['id'],
@@ -160,9 +179,9 @@ class TestDomains:
                     'purpose': first['purpose'],
                     'campaignId': first['campaign_id'],
                     'campaignName': None,
-                    'validationFailed': False,
                     'isARecordSet': first['is_a_record_set'],
                     'isDisabled': first['is_disabled'],
+                    'certificateStatus': None,
                 },
                 {
                     'id': second['id'],
@@ -170,9 +189,9 @@ class TestDomains:
                     'purpose': second['purpose'],
                     'campaignId': second['campaign_id'],
                     'campaignName': None,
-                    'validationFailed': False,
                     'isARecordSet': second['is_a_record_set'],
                     'isDisabled': second['is_disabled'],
+                    'certificateStatus': None,
                 },
             ],
             'pagination': {'page': 1, 'pageSize': 3, 'sortBy': 'hostname', 'sortOrder': 'desc', 'total': 3},
@@ -188,9 +207,44 @@ class TestDomains:
             'purpose': domain['purpose'],
             'campaignId': domain['campaign_id'],
             'campaignName': campaign['name'],
-            'validationFailed': False,
             'isARecordSet': domain['is_a_record_set'],
             'isDisabled': domain['is_disabled'],
+            'certificateStatus': None,
+        }
+
+    def test_get_domain_returns_certificate_status(self, client, authorization, domain, campaign, write_to_db):
+        certificate = write_to_db(
+            'domain_certificate',
+            {
+                'domain_id': domain['id'],
+                'status': 'active',
+                'ca': 'letsencrypt',
+                'validation_method': 'http-01-webroot',
+                'certificate_path': '/etc/nginx/bangi/certs/campaign.example.com/fullchain.pem',
+                'private_key_path': '/etc/nginx/bangi/certs/campaign.example.com/privkey.pem',
+                'issued_at': 1778587200,
+                'expires_at': 1786363200,
+                'last_attempted_at': 1778587200,
+                'last_issued_at': 1778587200,
+                'last_renewed_at': None,
+                'next_retry_at': None,
+                'failure_count': 0,
+                'failure_reason': None,
+            },
+        )
+
+        response = client.get(f'/api/v2/domains/{domain["id"]}', headers={'Authorization': authorization})
+
+        assert response.status_code == 200, response.text
+        assert response.json == {
+            'id': domain['id'],
+            'hostname': domain['hostname'],
+            'purpose': domain['purpose'],
+            'campaignId': domain['campaign_id'],
+            'campaignName': campaign['name'],
+            'isARecordSet': domain['is_a_record_set'],
+            'isDisabled': domain['is_disabled'],
+            'certificateStatus': certificate['status'],
         }
 
     def test_get_domain__non_existent(self, client, authorization):
@@ -198,6 +252,12 @@ class TestDomains:
 
         assert response.status_code == 404, response.text
         assert response.json == {'message': 'Domain does not exist'}
+
+    def test_get_domain_certificate__non_existent(self, client, authorization, domain):
+        response = client.get(f'/api/v2/domains/{domain["id"]}/certificate', headers={'Authorization': authorization})
+
+        assert response.status_code == 404, response.text
+        assert response.json == {'message': 'Domain certificate does not exist'}
 
     def test_update_domain_resets_dns_when_hostname_changes(
         self, client, authorization, write_to_db, read_from_db, nginx_workspace_base_dir
@@ -230,9 +290,9 @@ class TestDomains:
             'purpose': 'campaign',
             'campaignId': None,
             'campaignName': None,
-            'validationFailed': False,
             'isARecordSet': None,
             'isDisabled': False,
+            'certificateStatus': None,
         }
 
         updated = read_from_db('domain', filters={'id': domain['id']})
@@ -253,7 +313,7 @@ class TestDomains:
         assert new_enabled_link.is_symlink()
 
     def test_update_domain_to_disabled_keeps_certificate_metadata_unchanged(
-        self, client, authorization, domain, read_from_db, write_to_db
+        self, client, authorization, domain, campaign, read_from_db, write_to_db
     ):
         certificate = write_to_db(
             'domain_certificate',
@@ -282,6 +342,16 @@ class TestDomains:
         )
 
         assert response.status_code == 200, response.text
+        assert response.json == {
+            'id': domain['id'],
+            'hostname': domain['hostname'],
+            'purpose': domain['purpose'],
+            'campaignId': domain['campaign_id'],
+            'campaignName': campaign['name'],
+            'isARecordSet': True,
+            'isDisabled': True,
+            'certificateStatus': 'active',
+        }
         assert read_from_db('domain_certificate', filters={'id': certificate['id']}) == certificate
 
     def test_update_domain_attaches_campaign(self, client, authorization, campaign, write_to_db, read_from_db):
@@ -311,9 +381,9 @@ class TestDomains:
             'purpose': 'campaign',
             'campaignId': campaign['id'],
             'campaignName': campaign['name'],
-            'validationFailed': False,
             'isARecordSet': True,
             'isDisabled': False,
+            'certificateStatus': None,
         }
 
         updated = read_from_db('domain', filters={'id': domain['id']})
@@ -458,9 +528,9 @@ class TestDomains:
             'purpose': 'dashboard',
             'campaignId': None,
             'campaignName': None,
-            'validationFailed': False,
             'isARecordSet': True,
             'isDisabled': False,
+            'certificateStatus': None,
         }
 
         updated = read_from_db('domain', filters={'id': domain['id']})
@@ -522,9 +592,9 @@ class TestDomains:
             'purpose': 'dashboard',
             'campaignId': None,
             'campaignName': None,
-            'validationFailed': False,
             'isARecordSet': True,
             'isDisabled': False,
+            'certificateStatus': None,
         }
 
         updated = read_from_db('domain', filters={'id': domain['id']})

--- a/apps/api/tests/integration/facebook_pacs/test_ad_cabinets.py
+++ b/apps/api/tests/integration/facebook_pacs/test_ad_cabinets.py
@@ -133,7 +133,7 @@ class TestAdCabinet:
             f'/api/v2/facebook/pacs/ad-cabinets/{ad_cabinet["id"]}/business-portfolio/{business_portfolio["id"]}',
             headers={'Authorization': authorization},
         )
-        assert response.status_code == 201
+        assert response.status_code == 201, response.text
         assert response.json == {
             'id': ad_cabinet['id'],
             'isBanned': ad_cabinet['is_banned'],
@@ -163,7 +163,7 @@ class TestAdCabinetWithBusinessPortfolio:
             f'/api/v2/facebook/pacs/ad-cabinets/{ad_cabinet["id"]}/business-portfolio/{business_portfolio["id"]}',
             headers={'Authorization': authorization},
         )
-        assert response.status_code == 204
+        assert response.status_code == 204, response.text
 
         db_payload = read_from_db('facebook_pacs_ad_cabinet', filters={'id': ad_cabinet['id']})
         assert db_payload['business_portfolio_id'] is None
@@ -176,5 +176,5 @@ class TestAdCabinetWithBusinessPortfolio:
             f'/api/v2/facebook/pacs/ad-cabinets/{ad_cabinet["id"]}/business-portfolio/{nonexistent_manager_id}',
             headers={'Authorization': authorization},
         )
-        assert response.status_code == 400
+        assert response.status_code == 400, response.text
         assert response.json == {'message': 'Bad Business Manager'}

--- a/apps/api/tests/integration/facebook_pacs/test_business_portfolios.py
+++ b/apps/api/tests/integration/facebook_pacs/test_business_portfolios.py
@@ -145,7 +145,7 @@ class TestBusinessPortfolio:
             f'/api/v2/facebook/pacs/business-portfolios/{business_portfolio["id"]}/executors/{executor["id"]}',
             headers={'Authorization': authorization},
         )
-        assert response.status_code == 201
+        assert response.status_code == 201, response.text
         assert response.json == {
             'id': business_portfolio['id'],
             'name': business_portfolio['name'],
@@ -189,7 +189,7 @@ class TestBusinessPortfolio:
             f'/api/v2/facebook/pacs/business-portfolios/{business_portfolio["id"]}/executors/{executor["id"]}',
             headers={'Authorization': authorization},
         )
-        assert response.status_code == 204
+        assert response.status_code == 204, response.text
 
         db_payload = read_from_db(
             'facebook_pacs_business_portfolio2executor',
@@ -204,7 +204,7 @@ class TestBusinessPortfolio:
             f'/api/v2/facebook/pacs/business-portfolios/{business_portfolio["id"]}/executors/{executor["id"]}',
             headers={'Authorization': authorization},
         )
-        assert response.status_code == 204
+        assert response.status_code == 204, response.text
 
         db_payload = read_from_db(
             'facebook_pacs_business_portfolio2executor',
@@ -222,7 +222,7 @@ class TestBusinessPortfolio:
             f'/{business_portfolio["id"]}/executors/{non_existent_executor}',
             headers={'Authorization': authorization},
         )
-        assert response.status_code == 404
+        assert response.status_code == 404, response.text
         assert response.json == {'message': 'Does not exist'}
 
 

--- a/infra/installer/install.sh
+++ b/infra/installer/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-BANGI_RELEASE_TAG="0.0.1a27"
+BANGI_RELEASE_TAG="0.0.1a28"
 BANGI_GITHUB_OWNER="devalentino"
 BANGI_GITHUB_REPO="bangi"
 BANGI_RAW_BASE_URL="https://raw.githubusercontent.com/${BANGI_GITHUB_OWNER}/${BANGI_GITHUB_REPO}/${BANGI_RELEASE_TAG}"

--- a/infra/installer/templates/compose.prod.yml
+++ b/infra/installer/templates/compose.prod.yml
@@ -1,6 +1,6 @@
 services:
   web:
-    image: ghcr.io/devalentino/bangi-web:0.0.1a27
+    image: ghcr.io/devalentino/bangi-web:0.0.1a28
     restart: always
     env_file:
       - /opt/bangi/shared/env/.env
@@ -10,7 +10,7 @@ services:
       - bangi
 
   api:
-    image: ghcr.io/devalentino/bangi-api:0.0.1a27
+    image: ghcr.io/devalentino/bangi-api:0.0.1a28
     restart: always
     env_file:
       - /opt/bangi/shared/env/.env


### PR DESCRIPTION
## Summary
- Adds `AcmeService` as the host-command boundary for managed certificate issuance and renewal.
- Parses the raw `acme.sh` wrapper output in backend code, then reads certificate metadata from the installed certificate with `openssl` so `issued_at` and `expires_at` are available for renewal logic.
- Keeps the existing domain certificate response shape aligned with certificate status tracking and the read-only certificate endpoint.

## Scope
- Included:
  - `apps/api/src/domains/services.py`
- Not included:
  - The periodic certificate renewal worker
  - New public certificate mutation endpoints
  - Wrapper script changes outside the backend parsing path

## Risks
- The backend now depends on the human-readable `acme.sh` success lines and `openssl x509` output format. If either changes upstream, parsing will fail closed and surface in logs.
- Certificate metadata depends on the installed fullchain file being readable from the host wrapper context.

## Links
- Jira: KAN-45
- Spec: _bmad-output/planning-artifacts/managed-https-certificates-tech-spec.md
