### PR TITLE
KAN-47: feat: render ACME and HTTPS Nginx configs

### DIFF
--- a/apps/api/src/domains/nginx_templates/campaign_http.conf.template
+++ b/apps/api/src/domains/nginx_templates/campaign_http.conf.template
@@ -1,0 +1,29 @@
+# Managed by Bangi. Campaign domain.
+server {
+    listen 80;
+    listen [::]:80;
+    server_name ${hostname};
+
+    location ^~ /.well-known/acme-challenge/ {
+        root /etc/nginx/bangi/acme-challenges;
+        default_type "text/plain";
+        try_files $$uri =404;
+    }
+
+    set $$bangi_campaign_upstream "http://127.0.0.1:8000/process/${campaign_id}";
+    if ($$cookie_${flow_id_cookie_name} != "") {
+        set $$bangi_campaign_upstream "http://127.0.0.1:8081/$$cookie_${flow_id_cookie_name}/";
+    }
+
+    location = / {
+        proxy_pass $$bangi_campaign_upstream;
+    }
+
+    location / {
+        if ($$cookie_${flow_id_cookie_name} = "") {
+            return 404;
+        }
+
+        proxy_pass http://127.0.0.1:8081/$$cookie_${flow_id_cookie_name}/;
+    }
+}

--- a/apps/api/src/domains/nginx_templates/campaign_https.conf.template
+++ b/apps/api/src/domains/nginx_templates/campaign_https.conf.template
@@ -1,0 +1,42 @@
+# Managed by Bangi. Campaign domain.
+server {
+    listen 80;
+    listen [::]:80;
+    server_name ${hostname};
+
+    location ^~ /.well-known/acme-challenge/ {
+        root /etc/nginx/bangi/acme-challenges;
+        default_type "text/plain";
+        try_files $$uri =404;
+    }
+
+    location / {
+        return 301 https://$$host$$request_uri;
+    }
+}
+
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+    server_name ${hostname};
+
+    ssl_certificate ${certificate_path};
+    ssl_certificate_key ${private_key_path};
+
+    set $$bangi_campaign_upstream "http://127.0.0.1:8000/process/${campaign_id}";
+    if ($$cookie_${flow_id_cookie_name} != "") {
+        set $$bangi_campaign_upstream "http://127.0.0.1:8081/$$cookie_${flow_id_cookie_name}/";
+    }
+
+    location = / {
+        proxy_pass $$bangi_campaign_upstream;
+    }
+
+    location / {
+        if ($$cookie_${flow_id_cookie_name} = "") {
+            return 404;
+        }
+
+        proxy_pass http://127.0.0.1:8081/$$cookie_${flow_id_cookie_name}/;
+    }
+}

--- a/apps/api/src/domains/nginx_templates/dashboard_http.conf.template
+++ b/apps/api/src/domains/nginx_templates/dashboard_http.conf.template
@@ -1,0 +1,24 @@
+# Managed by Bangi. Dashboard domain.
+server {
+    listen 80;
+    listen [::]:80;
+    server_name ${hostname};
+
+    location ^~ /.well-known/acme-challenge/ {
+        root /etc/nginx/bangi/acme-challenges;
+        default_type "text/plain";
+        try_files $$uri =404;
+    }
+
+    location /api/ {
+        proxy_pass http://127.0.0.1:8000;
+    }
+
+    location /process {
+        return 404;
+    }
+
+    location / {
+        proxy_pass http://127.0.0.1:8080;
+    }
+}

--- a/apps/api/src/domains/nginx_templates/dashboard_https.conf.template
+++ b/apps/api/src/domains/nginx_templates/dashboard_https.conf.template
@@ -1,0 +1,37 @@
+# Managed by Bangi. Dashboard domain.
+server {
+    listen 80;
+    listen [::]:80;
+    server_name ${hostname};
+
+    location ^~ /.well-known/acme-challenge/ {
+        root /etc/nginx/bangi/acme-challenges;
+        default_type "text/plain";
+        try_files $$uri =404;
+    }
+
+    location / {
+        return 301 https://$$host$$request_uri;
+    }
+}
+
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+    server_name ${hostname};
+
+    ssl_certificate ${certificate_path};
+    ssl_certificate_key ${private_key_path};
+
+    location /api/ {
+        proxy_pass http://127.0.0.1:8000;
+    }
+
+    location /process {
+        return 404;
+    }
+
+    location / {
+        proxy_pass http://127.0.0.1:8080;
+    }
+}

--- a/apps/api/src/domains/nginx_templates/disabled_http.conf.template
+++ b/apps/api/src/domains/nginx_templates/disabled_http.conf.template
@@ -1,0 +1,16 @@
+# Managed by Bangi. Disabled or unroutable domain.
+server {
+    listen 80;
+    listen [::]:80;
+    server_name ${hostname};
+
+    location ^~ /.well-known/acme-challenge/ {
+        root /etc/nginx/bangi/acme-challenges;
+        default_type "text/plain";
+        try_files $$uri =404;
+    }
+
+    location / {
+        return 503;
+    }
+}

--- a/apps/api/src/domains/services.py
+++ b/apps/api/src/domains/services.py
@@ -100,6 +100,8 @@ class WebserverService(Protocol):
         flow_id_cookie_name: str | None,
         is_disabled: bool,
         is_a_record_set: bool | None,
+        certificate_path: str | None = None,
+        private_key_path: str | None = None,
     ) -> WebserverPublishResult:
         pass
 
@@ -324,6 +326,18 @@ class DomainService:
                 DomainCookieName.flow_id,
             )
 
+        certificate = DomainCertificate.get_or_none(DomainCertificate.domain == domain.id)
+        certificate_path = None
+        private_key_path = None
+        if (
+            certificate is not None
+            and certificate.status == DomainCertificateStatus.active
+            and certificate.certificate_path
+            and certificate.private_key_path
+        ):
+            certificate_path = certificate.certificate_path
+            private_key_path = certificate.private_key_path
+
         snapshot = self.webserver_service.publish(
             domain.hostname,
             domain.purpose,
@@ -331,6 +345,8 @@ class DomainService:
             flow_id_cookie_name,
             bool(domain.is_disabled),
             None if domain.is_a_record_set is None else bool(domain.is_a_record_set),
+            certificate_path,
+            private_key_path,
         )
         self.health_service.record_nginx_validation_snapshot(
             domain_id=domain.id,
@@ -568,6 +584,8 @@ class NginxService:
         flow_id_cookie_name: str | None,
         is_disabled: bool,
         is_a_record_set: bool | None,
+        certificate_path: str | None = None,
+        private_key_path: str | None = None,
     ) -> WebserverPublishResult:
         version = self._next_version()
         available_dir = self._site_available_dir(hostname)
@@ -582,18 +600,21 @@ class NginxService:
             flow_id_cookie_name=flow_id_cookie_name,
             is_disabled=is_disabled,
             is_a_record_set=is_a_record_set,
+            certificate_path=certificate_path,
+            private_key_path=private_key_path,
         )
         self._write_versioned_config(versioned_config_path, config_content)
+        self._activate_version(enabled_link, versioned_config_path)
+
         validation_error = self._validate_host_nginx()
         if validation_error is not None:
+            self._restore_previous_active(enabled_link, previous_active_target)
             return WebserverPublishResult(
                 validation_status='failed',
                 validation_error=validation_error,
                 sites_available_files=self._list_sites_available_files(),
                 sites_enabled_refs=self._list_sites_enabled_refs(),
             )
-
-        self._activate_version(enabled_link, versioned_config_path)
 
         reload_error = self._reload_host_nginx()
         if reload_error is not None:
@@ -640,79 +661,79 @@ class NginxService:
         flow_id_cookie_name: str | None,
         is_disabled: bool,
         is_a_record_set: bool | None,
+        certificate_path: str | None,
+        private_key_path: str | None,
     ) -> str:
         if is_disabled or is_a_record_set is False or (purpose == 'campaign' and campaign_id is None):
             return self.render_disabled_domain_config(hostname)
 
+        has_active_certificate = certificate_path is not None and private_key_path is not None
         if purpose == 'dashboard':
+            if has_active_certificate:
+                return self.render_dashboard_domain_config(hostname, certificate_path, private_key_path)
             return self.render_dashboard_domain_config(hostname)
 
         if flow_id_cookie_name is None:
             raise ValueError('flow_id_cookie_name is required for campaign domains')
+        if has_active_certificate:
+            return self.render_campaign_domain_config(
+                hostname,
+                campaign_id,
+                flow_id_cookie_name,
+                certificate_path,
+                private_key_path,
+            )
         return self.render_campaign_domain_config(hostname, campaign_id, flow_id_cookie_name)
 
-    @staticmethod
-    def render_disabled_domain_config(hostname: str) -> str:
-        return (
-            '# Managed by Bangi. Disabled or unroutable domain.\n'
-            'server {\n'
-            '    listen 80;\n'
-            '    listen [::]:80;\n'
-            f'    server_name {hostname};\n'
-            '    return 503;\n'
-            '}\n'
+    @classmethod
+    def render_disabled_domain_config(cls, hostname: str) -> str:
+        return cls._render_template('disabled_http.conf.template', hostname=hostname)
+
+    @classmethod
+    def render_dashboard_domain_config(
+        cls,
+        hostname: str,
+        certificate_path: str | None = None,
+        private_key_path: str | None = None,
+    ) -> str:
+        if certificate_path is not None and private_key_path is not None:
+            return cls._render_template(
+                'dashboard_https.conf.template',
+                hostname=hostname,
+                certificate_path=certificate_path,
+                private_key_path=private_key_path,
+            )
+        return cls._render_template('dashboard_http.conf.template', hostname=hostname)
+
+    @classmethod
+    def render_campaign_domain_config(
+        cls,
+        hostname: str,
+        campaign_id: int,
+        flow_id_cookie_name: str,
+        certificate_path: str | None = None,
+        private_key_path: str | None = None,
+    ) -> str:
+        if certificate_path is not None and private_key_path is not None:
+            return cls._render_template(
+                'campaign_https.conf.template',
+                hostname=hostname,
+                campaign_id=str(campaign_id),
+                flow_id_cookie_name=flow_id_cookie_name,
+                certificate_path=certificate_path,
+                private_key_path=private_key_path,
+            )
+        return cls._render_template(
+            'campaign_http.conf.template',
+            hostname=hostname,
+            campaign_id=str(campaign_id),
+            flow_id_cookie_name=flow_id_cookie_name,
         )
 
     @staticmethod
-    def render_dashboard_domain_config(hostname: str) -> str:
-        return (
-            '# Managed by Bangi. Dashboard domain.\n'
-            'server {\n'
-            '    listen 80;\n'
-            '    listen [::]:80;\n'
-            f'    server_name {hostname};\n'
-            '\n'
-            '    location /api/ {\n'
-            '        proxy_pass http://127.0.0.1:8000;\n'
-            '    }\n'
-            '\n'
-            '    location /process {\n'
-            '        return 404;\n'
-            '    }\n'
-            '\n'
-            '    location / {\n'
-            '        proxy_pass http://127.0.0.1:8080;\n'
-            '    }\n'
-            '}\n'
-        )
-
-    @staticmethod
-    def render_campaign_domain_config(hostname: str, campaign_id: int, flow_id_cookie_name: str) -> str:
-        return (
-            '# Managed by Bangi. Campaign domain.\n'
-            'server {\n'
-            '    listen 80;\n'
-            '    listen [::]:80;\n'
-            f'    server_name {hostname};\n'
-            '\n'
-            f'    set $bangi_campaign_upstream "http://127.0.0.1:8000/process/{campaign_id}";\n'
-            f'    if ($cookie_{flow_id_cookie_name} != "") {{\n'
-            f'        set $bangi_campaign_upstream "http://127.0.0.1:8081/$cookie_{flow_id_cookie_name}/";\n'
-            '    }\n'
-            '\n'
-            '    location = / {\n'
-            '        proxy_pass $bangi_campaign_upstream;\n'
-            '    }\n'
-            '\n'
-            '    location / {\n'
-            f'        if ($cookie_{flow_id_cookie_name} = "") {{\n'
-            '            return 404;\n'
-            '        }\n'
-            '\n'
-            f'        proxy_pass http://127.0.0.1:8081/$cookie_{flow_id_cookie_name}/;\n'
-            '    }\n'
-            '}\n'
-        )
+    def _render_template(template_name: str, **context: str) -> str:
+        template_path = Path(__file__).parent / 'nginx_templates' / template_name
+        return string.Template(template_path.read_text(encoding='utf-8')).substitute(context)
 
     def _validate_host_nginx(self) -> str | None:
         try:

--- a/apps/api/src/domains/workers.py
+++ b/apps/api/src/domains/workers.py
@@ -22,9 +22,16 @@ def _get_public_host_ip() -> str:
 def _fetch_domains_needing_refresh(database):
     cursor = database.execute_sql(
         (
-            'SELECT id, hostname, purpose, campaign_id, is_a_record_set, is_disabled '
-            'FROM domain WHERE is_a_record_set IS NULL OR is_a_record_set = FALSE ORDER BY id ASC'
-        )
+            'SELECT domain.id, domain.hostname, domain.purpose, domain.campaign_id, '
+            'domain.is_a_record_set, domain.is_disabled, '
+            'domain_certificate.certificate_path, domain_certificate.private_key_path '
+            'FROM domain '
+            'LEFT JOIN domain_certificate '
+            'ON domain_certificate.domain_id = domain.id AND domain_certificate.status = %s '
+            'WHERE domain.is_a_record_set IS NULL OR domain.is_a_record_set = FALSE '
+            'ORDER BY domain.id ASC'
+        ),
+        ('active',),
     )
     return cursor.fetchall()
 
@@ -139,9 +146,16 @@ def refresh_domain_dns_worker(context: WorkerContext) -> None:
     processed_domain_ids = []
     pending_snapshots = []
 
-    for domain_id, hostname, purpose, campaign_id, is_a_record_set, is_disabled in _fetch_domains_needing_refresh(
-        database
-    ):
+    for (
+        domain_id,
+        hostname,
+        purpose,
+        campaign_id,
+        is_a_record_set,
+        is_disabled,
+        certificate_path,
+        private_key_path,
+    ) in _fetch_domains_needing_refresh(database):
         current_state = DnsService.has_a_record(hostname, public_host_ip)
         previous_state = None if is_a_record_set is None else bool(is_a_record_set)
 
@@ -160,6 +174,8 @@ def refresh_domain_dns_worker(context: WorkerContext) -> None:
                 flow_id_cookie_name,
                 bool(is_disabled),
                 current_state,
+                certificate_path,
+                private_key_path,
             )
             if snapshot.validation_status != 'success':
                 logger.warning(

--- a/apps/api/tests/integration/domains/test_nginx.py
+++ b/apps/api/tests/integration/domains/test_nginx.py
@@ -7,6 +7,169 @@ from unittest import mock
 import pytest
 
 
+def expected_acme_location():
+    return (
+        '    location ^~ /.well-known/acme-challenge/ {\n'
+        '        root /etc/nginx/bangi/acme-challenges;\n'
+        '        default_type "text/plain";\n'
+        '        try_files $uri =404;\n'
+        '    }\n'
+    )
+
+
+def expected_disabled_config(hostname):
+    return (
+        '# Managed by Bangi. Disabled or unroutable domain.\n'
+        'server {\n'
+        '    listen 80;\n'
+        '    listen [::]:80;\n'
+        f'    server_name {hostname};\n'
+        '\n'
+        f'{expected_acme_location()}'
+        '\n'
+        '    location / {\n'
+        '        return 503;\n'
+        '    }\n'
+        '}\n'
+    )
+
+
+def expected_dashboard_http_config(hostname):
+    return (
+        '# Managed by Bangi. Dashboard domain.\n'
+        'server {\n'
+        '    listen 80;\n'
+        '    listen [::]:80;\n'
+        f'    server_name {hostname};\n'
+        '\n'
+        f'{expected_acme_location()}'
+        '\n'
+        '    location /api/ {\n'
+        '        proxy_pass http://127.0.0.1:8000;\n'
+        '    }\n'
+        '\n'
+        '    location /process {\n'
+        '        return 404;\n'
+        '    }\n'
+        '\n'
+        '    location / {\n'
+        '        proxy_pass http://127.0.0.1:8080;\n'
+        '    }\n'
+        '}\n'
+    )
+
+
+def expected_dashboard_https_config(hostname, certificate_path, private_key_path):
+    return (
+        '# Managed by Bangi. Dashboard domain.\n'
+        'server {\n'
+        '    listen 80;\n'
+        '    listen [::]:80;\n'
+        f'    server_name {hostname};\n'
+        '\n'
+        f'{expected_acme_location()}'
+        '\n'
+        '    location / {\n'
+        '        return 301 https://$host$request_uri;\n'
+        '    }\n'
+        '}\n'
+        '\n'
+        'server {\n'
+        '    listen 443 ssl http2;\n'
+        '    listen [::]:443 ssl http2;\n'
+        f'    server_name {hostname};\n'
+        '\n'
+        f'    ssl_certificate {certificate_path};\n'
+        f'    ssl_certificate_key {private_key_path};\n'
+        '\n'
+        '    location /api/ {\n'
+        '        proxy_pass http://127.0.0.1:8000;\n'
+        '    }\n'
+        '\n'
+        '    location /process {\n'
+        '        return 404;\n'
+        '    }\n'
+        '\n'
+        '    location / {\n'
+        '        proxy_pass http://127.0.0.1:8080;\n'
+        '    }\n'
+        '}\n'
+    )
+
+
+def expected_campaign_http_config(hostname, campaign_id, flow_id_cookie_name):
+    return (
+        '# Managed by Bangi. Campaign domain.\n'
+        'server {\n'
+        '    listen 80;\n'
+        '    listen [::]:80;\n'
+        f'    server_name {hostname};\n'
+        '\n'
+        f'{expected_acme_location()}'
+        '\n'
+        f'    set $bangi_campaign_upstream "http://127.0.0.1:8000/process/{campaign_id}";\n'
+        f'    if ($cookie_{flow_id_cookie_name} != "") {{\n'
+        f'        set $bangi_campaign_upstream "http://127.0.0.1:8081/$cookie_{flow_id_cookie_name}/";\n'
+        '    }\n'
+        '\n'
+        '    location = / {\n'
+        '        proxy_pass $bangi_campaign_upstream;\n'
+        '    }\n'
+        '\n'
+        '    location / {\n'
+        f'        if ($cookie_{flow_id_cookie_name} = "") {{\n'
+        '            return 404;\n'
+        '        }\n'
+        '\n'
+        f'        proxy_pass http://127.0.0.1:8081/$cookie_{flow_id_cookie_name}/;\n'
+        '    }\n'
+        '}\n'
+    )
+
+
+def expected_campaign_https_config(hostname, campaign_id, flow_id_cookie_name, certificate_path, private_key_path):
+    return (
+        '# Managed by Bangi. Campaign domain.\n'
+        'server {\n'
+        '    listen 80;\n'
+        '    listen [::]:80;\n'
+        f'    server_name {hostname};\n'
+        '\n'
+        f'{expected_acme_location()}'
+        '\n'
+        '    location / {\n'
+        '        return 301 https://$host$request_uri;\n'
+        '    }\n'
+        '}\n'
+        '\n'
+        'server {\n'
+        '    listen 443 ssl http2;\n'
+        '    listen [::]:443 ssl http2;\n'
+        f'    server_name {hostname};\n'
+        '\n'
+        f'    ssl_certificate {certificate_path};\n'
+        f'    ssl_certificate_key {private_key_path};\n'
+        '\n'
+        f'    set $bangi_campaign_upstream "http://127.0.0.1:8000/process/{campaign_id}";\n'
+        f'    if ($cookie_{flow_id_cookie_name} != "") {{\n'
+        f'        set $bangi_campaign_upstream "http://127.0.0.1:8081/$cookie_{flow_id_cookie_name}/";\n'
+        '    }\n'
+        '\n'
+        '    location = / {\n'
+        '        proxy_pass $bangi_campaign_upstream;\n'
+        '    }\n'
+        '\n'
+        '    location / {\n'
+        f'        if ($cookie_{flow_id_cookie_name} = "") {{\n'
+        '            return 404;\n'
+        '        }\n'
+        '\n'
+        f'        proxy_pass http://127.0.0.1:8081/$cookie_{flow_id_cookie_name}/;\n'
+        '    }\n'
+        '}\n'
+    )
+
+
 @pytest.fixture
 def nginx_workspace_base_dir_cleanup(nginx_workspace_base_dir):
     shutil.rmtree(nginx_workspace_base_dir)
@@ -36,15 +199,7 @@ class TestDomainNginxPublication:
         versioned_configs = sorted(available_dir.glob('*.conf'))
 
         assert len(versioned_configs) == 1
-        assert versioned_configs[0].read_text(encoding='utf-8') == (
-            '# Managed by Bangi. Disabled or unroutable domain.\n'
-            'server {\n'
-            '    listen 80;\n'
-            '    listen [::]:80;\n'
-            '    server_name example.com;\n'
-            '    return 503;\n'
-            '}\n'
-        )
+        assert versioned_configs[0].read_text(encoding='utf-8') == expected_disabled_config('example.com')
         assert enabled_link.is_symlink()
         assert enabled_link.readlink().as_posix() == f'../sites-available/example.com/{versioned_configs[0].name}'
 
@@ -248,15 +403,7 @@ class TestDomainNginxConfigurations:
         versioned_configs = sorted(available_dir.glob('*.conf'))
 
         assert len(versioned_configs) == 1
-        assert versioned_configs[0].read_text(encoding='utf-8') == (
-            '# Managed by Bangi. Disabled or unroutable domain.\n'
-            'server {\n'
-            '    listen 80;\n'
-            '    listen [::]:80;\n'
-            f'    server_name {hostname};\n'
-            '    return 503;\n'
-            '}\n'
-        )
+        assert versioned_configs[0].read_text(encoding='utf-8') == expected_disabled_config(hostname)
 
     def test_campaign_domain_exists_campaign_got_attached_writes_campaign_config(
         self,
@@ -298,30 +445,10 @@ class TestDomainNginxConfigurations:
         }
 
         assert len(versioned_configs) == 1
-        assert versioned_configs[0].read_text(encoding='utf-8') == (
-            '# Managed by Bangi. Campaign domain.\n'
-            'server {\n'
-            '    listen 80;\n'
-            '    listen [::]:80;\n'
-            f'    server_name {hostname};\n'
-            '\n'
-            f'    set $bangi_campaign_upstream "http://127.0.0.1:8000/process/{campaign["id"]}";\n'
-            f'    if ($cookie_{cookie_row["opaque_name"]} != "") {{\n'
-            f'        set $bangi_campaign_upstream "http://127.0.0.1:8081/$cookie_{cookie_row["opaque_name"]}/";\n'
-            '    }\n'
-            '\n'
-            '    location = / {\n'
-            '        proxy_pass $bangi_campaign_upstream;\n'
-            '    }\n'
-            '\n'
-            '    location / {\n'
-            f'        if ($cookie_{cookie_row["opaque_name"]} = "") {{\n'
-            '            return 404;\n'
-            '        }\n'
-            '\n'
-            f'        proxy_pass http://127.0.0.1:8081/$cookie_{cookie_row["opaque_name"]}/;\n'
-            '    }\n'
-            '}\n'
+        assert versioned_configs[0].read_text(encoding='utf-8') == expected_campaign_http_config(
+            hostname,
+            campaign['id'],
+            cookie_row['opaque_name'],
         )
 
     def test_campaign_domain_exists_campaign_is_attached_got_detached_writes_disabled_config(
@@ -355,15 +482,7 @@ class TestDomainNginxConfigurations:
         versioned_configs = sorted(available_dir.glob('*.conf'))
 
         assert len(versioned_configs) == 1
-        assert versioned_configs[0].read_text(encoding='utf-8') == (
-            '# Managed by Bangi. Disabled or unroutable domain.\n'
-            'server {\n'
-            '    listen 80;\n'
-            '    listen [::]:80;\n'
-            f'    server_name {hostname};\n'
-            '    return 503;\n'
-            '}\n'
-        )
+        assert versioned_configs[0].read_text(encoding='utf-8') == expected_disabled_config(hostname)
 
     def test_campaign_domain_exists_campaign_is_detached_purpose_changed_to_dashboard_writes_dashboard_config(
         self,
@@ -395,26 +514,7 @@ class TestDomainNginxConfigurations:
         versioned_configs = sorted(available_dir.glob('*.conf'))
 
         assert len(versioned_configs) == 1
-        assert versioned_configs[0].read_text(encoding='utf-8') == (
-            '# Managed by Bangi. Dashboard domain.\n'
-            'server {\n'
-            '    listen 80;\n'
-            '    listen [::]:80;\n'
-            f'    server_name {hostname};\n'
-            '\n'
-            '    location /api/ {\n'
-            '        proxy_pass http://127.0.0.1:8000;\n'
-            '    }\n'
-            '\n'
-            '    location /process {\n'
-            '        return 404;\n'
-            '    }\n'
-            '\n'
-            '    location / {\n'
-            '        proxy_pass http://127.0.0.1:8080;\n'
-            '    }\n'
-            '}\n'
-        )
+        assert versioned_configs[0].read_text(encoding='utf-8') == expected_dashboard_http_config(hostname)
 
     def test_dashboard_domain_created_writes_dashboard_config(self, client, authorization, nginx_workspace_base_dir):
         hostname = 'dashboard-created.example.com'
@@ -429,26 +529,7 @@ class TestDomainNginxConfigurations:
         versioned_configs = sorted(available_dir.glob('*.conf'))
 
         assert len(versioned_configs) == 1
-        assert versioned_configs[0].read_text(encoding='utf-8') == (
-            '# Managed by Bangi. Dashboard domain.\n'
-            'server {\n'
-            '    listen 80;\n'
-            '    listen [::]:80;\n'
-            f'    server_name {hostname};\n'
-            '\n'
-            '    location /api/ {\n'
-            '        proxy_pass http://127.0.0.1:8000;\n'
-            '    }\n'
-            '\n'
-            '    location /process {\n'
-            '        return 404;\n'
-            '    }\n'
-            '\n'
-            '    location / {\n'
-            '        proxy_pass http://127.0.0.1:8080;\n'
-            '    }\n'
-            '}\n'
-        )
+        assert versioned_configs[0].read_text(encoding='utf-8') == expected_dashboard_http_config(hostname)
 
     def test_dashboard_domain_exists_purpose_changed_to_campaign_writes_disabled_config(
         self,
@@ -480,15 +561,7 @@ class TestDomainNginxConfigurations:
         versioned_configs = sorted(available_dir.glob('*.conf'))
 
         assert len(versioned_configs) == 1
-        assert versioned_configs[0].read_text(encoding='utf-8') == (
-            '# Managed by Bangi. Disabled or unroutable domain.\n'
-            'server {\n'
-            '    listen 80;\n'
-            '    listen [::]:80;\n'
-            f'    server_name {hostname};\n'
-            '    return 503;\n'
-            '}\n'
-        )
+        assert versioned_configs[0].read_text(encoding='utf-8') == expected_disabled_config(hostname)
 
     def test_dashboard_domain_exists_purpose_changed_to_campaign_campaign_attached_writes_campaign_config(
         self,
@@ -530,28 +603,178 @@ class TestDomainNginxConfigurations:
         }
 
         assert len(versioned_configs) == 1
-        assert versioned_configs[0].read_text(encoding='utf-8') == (
-            '# Managed by Bangi. Campaign domain.\n'
-            'server {\n'
-            '    listen 80;\n'
-            '    listen [::]:80;\n'
-            f'    server_name {hostname};\n'
-            '\n'
-            f'    set $bangi_campaign_upstream "http://127.0.0.1:8000/process/{campaign["id"]}";\n'
-            f'    if ($cookie_{cookie_row["opaque_name"]} != "") {{\n'
-            f'        set $bangi_campaign_upstream "http://127.0.0.1:8081/$cookie_{cookie_row["opaque_name"]}/";\n'
-            '    }\n'
-            '\n'
-            '    location = / {\n'
-            '        proxy_pass $bangi_campaign_upstream;\n'
-            '    }\n'
-            '\n'
-            '    location / {\n'
-            f'        if ($cookie_{cookie_row["opaque_name"]} = "") {{\n'
-            '            return 404;\n'
-            '        }\n'
-            '\n'
-            f'        proxy_pass http://127.0.0.1:8081/$cookie_{cookie_row["opaque_name"]}/;\n'
-            '    }\n'
-            '}\n'
+        assert versioned_configs[0].read_text(encoding='utf-8') == expected_campaign_http_config(
+            hostname,
+            campaign['id'],
+            cookie_row['opaque_name'],
         )
+
+    def test_campaign_domain_with_active_certificate_writes_https_config(
+        self,
+        client,
+        authorization,
+        campaign,
+        nginx_workspace_base_dir,
+        read_from_db,
+        write_to_db,
+    ):
+        hostname = 'campaign-https.example.com'
+        certificate_path = f'/etc/nginx/bangi/certs/{hostname}/fullchain.pem'
+        private_key_path = f'/etc/nginx/bangi/certs/{hostname}/privkey.pem'
+        domain = write_to_db(
+            'domain',
+            {
+                'hostname': hostname,
+                'purpose': 'campaign',
+                'campaign_id': None,
+                'is_a_record_set': True,
+                'is_disabled': False,
+            },
+        )
+        write_to_db(
+            'domain_certificate',
+            {
+                'domain_id': domain['id'],
+                'status': 'active',
+                'ca': 'letsencrypt',
+                'validation_method': 'http-01-webroot',
+                'certificate_path': certificate_path,
+                'private_key_path': private_key_path,
+                'issued_at': 1778587200,
+                'expires_at': 1786363200,
+                'last_attempted_at': 1778587200,
+                'last_issued_at': 1778587200,
+                'last_renewed_at': None,
+                'next_retry_at': None,
+                'failure_count': 0,
+                'failure_reason': None,
+            },
+        )
+
+        response = client.patch(
+            f'/api/v2/domains/{domain["id"]}',
+            headers={'Authorization': authorization},
+            json={'campaignId': campaign['id']},
+        )
+
+        assert response.status_code == 200, response.text
+        available_dir = Path(nginx_workspace_base_dir) / 'sites-available' / hostname
+        versioned_configs = sorted(available_dir.glob('*.conf'))
+        cookie_row = read_from_db('domain_cookie', filters={'domain_id': domain['id'], 'name': 'flow_id'})
+
+        assert len(versioned_configs) == 1
+        assert versioned_configs[0].read_text(encoding='utf-8') == expected_campaign_https_config(
+            hostname,
+            campaign['id'],
+            cookie_row['opaque_name'],
+            certificate_path,
+            private_key_path,
+        )
+
+    def test_dashboard_domain_with_active_certificate_writes_https_config(
+        self,
+        client,
+        authorization,
+        nginx_workspace_base_dir,
+        write_to_db,
+    ):
+        hostname = 'dashboard-https.example.com'
+        certificate_path = f'/etc/nginx/bangi/certs/{hostname}/fullchain.pem'
+        private_key_path = f'/etc/nginx/bangi/certs/{hostname}/privkey.pem'
+        domain = write_to_db(
+            'domain',
+            {
+                'hostname': hostname,
+                'purpose': 'campaign',
+                'campaign_id': None,
+                'is_a_record_set': True,
+                'is_disabled': False,
+            },
+        )
+        write_to_db(
+            'domain_certificate',
+            {
+                'domain_id': domain['id'],
+                'status': 'active',
+                'ca': 'letsencrypt',
+                'validation_method': 'http-01-webroot',
+                'certificate_path': certificate_path,
+                'private_key_path': private_key_path,
+                'issued_at': 1778587200,
+                'expires_at': 1786363200,
+                'last_attempted_at': 1778587200,
+                'last_issued_at': 1778587200,
+                'last_renewed_at': None,
+                'next_retry_at': None,
+                'failure_count': 0,
+                'failure_reason': None,
+            },
+        )
+
+        response = client.patch(
+            f'/api/v2/domains/{domain["id"]}',
+            headers={'Authorization': authorization},
+            json={'purpose': 'dashboard', 'campaignId': None},
+        )
+
+        assert response.status_code == 200, response.text
+        available_dir = Path(nginx_workspace_base_dir) / 'sites-available' / hostname
+        versioned_configs = sorted(available_dir.glob('*.conf'))
+
+        assert len(versioned_configs) == 1
+        assert versioned_configs[0].read_text(encoding='utf-8') == expected_dashboard_https_config(
+            hostname,
+            certificate_path,
+            private_key_path,
+        )
+
+    def test_domain_without_active_certificate_writes_http_config(
+        self,
+        client,
+        authorization,
+        nginx_workspace_base_dir,
+        write_to_db,
+    ):
+        hostname = 'dashboard-failed-certificate.example.com'
+        domain = write_to_db(
+            'domain',
+            {
+                'hostname': hostname,
+                'purpose': 'campaign',
+                'campaign_id': None,
+                'is_a_record_set': True,
+                'is_disabled': False,
+            },
+        )
+        write_to_db(
+            'domain_certificate',
+            {
+                'domain_id': domain['id'],
+                'status': 'failed',
+                'ca': 'letsencrypt',
+                'validation_method': 'http-01-webroot',
+                'certificate_path': f'/etc/nginx/bangi/certs/{hostname}/fullchain.pem',
+                'private_key_path': f'/etc/nginx/bangi/certs/{hostname}/privkey.pem',
+                'issued_at': 1778587200,
+                'expires_at': 1786363200,
+                'last_attempted_at': 1778587200,
+                'last_issued_at': 1778587200,
+                'last_renewed_at': None,
+                'next_retry_at': None,
+                'failure_count': 1,
+                'failure_reason': 'ACME challenge failed',
+            },
+        )
+
+        response = client.patch(
+            f'/api/v2/domains/{domain["id"]}',
+            headers={'Authorization': authorization},
+            json={'purpose': 'dashboard', 'campaignId': None},
+        )
+
+        assert response.status_code == 200, response.text
+        available_dir = Path(nginx_workspace_base_dir) / 'sites-available' / hostname
+        versioned_configs = sorted(available_dir.glob('*.conf'))
+
+        assert len(versioned_configs) == 1
+        assert versioned_configs[0].read_text(encoding='utf-8') == expected_dashboard_http_config(hostname)

--- a/infra/installer/install.sh
+++ b/infra/installer/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-BANGI_RELEASE_TAG="0.0.1a29"
+BANGI_RELEASE_TAG="0.0.1a30"
 BANGI_GITHUB_OWNER="devalentino"
 BANGI_GITHUB_REPO="bangi"
 BANGI_RAW_BASE_URL="https://raw.githubusercontent.com/${BANGI_GITHUB_OWNER}/${BANGI_GITHUB_REPO}/${BANGI_RELEASE_TAG}"

--- a/infra/installer/templates/compose.prod.yml
+++ b/infra/installer/templates/compose.prod.yml
@@ -1,6 +1,6 @@
 services:
   web:
-    image: ghcr.io/devalentino/bangi-web:0.0.1a29
+    image: ghcr.io/devalentino/bangi-web:0.0.1a30
     restart: always
     env_file:
       - /opt/bangi/shared/env/.env
@@ -10,7 +10,7 @@ services:
       - bangi
 
   api:
-    image: ghcr.io/devalentino/bangi-api:0.0.1a29
+    image: ghcr.io/devalentino/bangi-api:0.0.1a30
     restart: always
     env_file:
       - /opt/bangi/shared/env/.env


### PR DESCRIPTION
## Summary
- Move managed-domain Nginx rendering from inline Python strings to file-based `string.Template` templates.
- Add ACME HTTP-01 challenge locations to campaign, dashboard, and disabled HTTP server configs before redirect/proxy/fallback behavior.
- Render HTTPS campaign/dashboard configs when active certificate metadata has both `fullchain.pem` and `privkey.pem`, and validate/reload through the existing publication flow with rollback.
- Preserve active certificate paths during DNS refresh republish so domains are not downgraded to HTTP.

## Scope
- Included:
- Nginx templates for campaign HTTP/HTTPS, dashboard HTTP/HTTPS, and disabled HTTP domains.
- Certificate-aware Nginx publishing and DNS refresh republishing.
- Integration coverage for ACME challenge locations, HTTPS rendering, and HTTP fallback without active certificates.
- Not included:
- Certificate worker scheduling or ACME issuance/renewal candidate selection.
- Public certificate mutation endpoints.
- Frontend certificate UI changes.

## Risks
- Medium: Nginx publication now activates the candidate symlink before validation so `nginx-validate` checks the new config, then restores the previous symlink if validation or reload fails.
- Low: template rendering uses escaped Nginx `$` variables; integration assertions cover rendered output.

## Links
- Jira: https://bangitech.atlassian.net/browse/KAN-47
- Spec: https://bangitech.atlassian.net/wiki/spaces/SD/pages/10977282/Managed+HTTPS+Certificates+-+Technical+Spec
