### PR TITLE
KAN-49: feat: show domain certificate status in UI

### DIFF
--- a/apps/api/tests/integration/domains/test_domains.py
+++ b/apps/api/tests/integration/domains/test_domains.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timedelta, timezone
 from unittest import mock
 
 import pytest
@@ -258,6 +259,47 @@ class TestDomains:
 
         assert response.status_code == 404, response.text
         assert response.json == {'message': 'Domain certificate does not exist'}
+
+    def test_get_domain_certificate_returns_full_payload_without_file_paths(
+        self, client, authorization, domain, write_to_db
+    ):
+        expires_at = int((datetime.now(timezone.utc) + timedelta(days=90)).timestamp())
+        last_attempted_at = 1778587200
+        last_issued_at = 1778587200
+        certificate = write_to_db(
+            'domain_certificate',
+            {
+                'domain_id': domain['id'],
+                'status': 'active',
+                'ca': 'letsencrypt',
+                'validation_method': 'http-01-webroot',
+                'certificate_path': '/etc/nginx/bangi/certs/campaign.example.com/fullchain.pem',
+                'private_key_path': '/etc/nginx/bangi/certs/campaign.example.com/privkey.pem',
+                'issued_at': 1778583600,
+                'expires_at': expires_at,
+                'last_attempted_at': last_attempted_at,
+                'last_issued_at': last_issued_at,
+                'last_renewed_at': None,
+                'next_retry_at': None,
+                'failure_count': 0,
+                'failure_reason': None,
+            },
+        )
+
+        response = client.get(f'/api/v2/domains/{domain["id"]}/certificate', headers={'Authorization': authorization})
+
+        assert response.status_code == 200, response.text
+        assert response.json == {
+            'status': certificate['status'],
+            'ca': certificate['ca'],
+            'validationMethod': certificate['validation_method'],
+            'expiresAt': expires_at,
+            'lastAttemptedAt': last_attempted_at,
+            'lastIssuedAt': last_issued_at,
+            'lastRenewedAt': None,
+            'nextRetryAt': None,
+            'failureReason': None,
+        }
 
     def test_update_domain_resets_dns_when_hostname_changes(
         self, client, authorization, write_to_db, read_from_db, nginx_workspace_base_dir

--- a/apps/web/src/config.js
+++ b/apps/web/src/config.js
@@ -4,7 +4,7 @@ if (typeof window !== "undefined" && window.APP_CONFIG) {
   runtimeConfig = window.APP_CONFIG;
 }
 
-var backendApiBaseUrl = "http://209.38.195.236/api/v2";
+var backendApiBaseUrl = "http://159.65.117.52/api/v2";
 var debugPersistentAuth = runtimeConfig.DEBUG_PERSIST_AUTH === true
   || runtimeConfig.DEBUG_PERSIST_AUTH === "true";
 

--- a/apps/web/src/models/domain.js
+++ b/apps/web/src/models/domain.js
@@ -12,6 +12,9 @@ class DomainModel {
     this.campaigns = [];
     this.campaignError = null;
     this.domain = null;
+    this.certificate = null;
+    this.certificateError = null;
+    this.isCertificateLoading = false;
     this.form = {
       hostname: "",
       purpose: "campaign",
@@ -63,6 +66,9 @@ class DomainModel {
     this.error = null;
     this.successMessage = null;
     this.lastLoaded = null;
+    this.certificate = null;
+    this.certificateError = null;
+    this.isCertificateLoading = false;
     this.isLoading = true;
 
     api.request({
@@ -74,10 +80,32 @@ class DomainModel {
         this.lastLoaded = payload;
         this.setFormValues(payload);
         this.isLoading = false;
+        if (payload.certificateStatus) {
+          this.fetchCertificate();
+        }
       }.bind(this))
       .catch(function () {
         this.error = "Failed to load domain details.";
         this.isLoading = false;
+      }.bind(this));
+  }
+
+  fetchCertificate() {
+    this.certificate = null;
+    this.certificateError = null;
+    this.isCertificateLoading = true;
+
+    api.request({
+      method: "GET",
+      url: `${config.backendApiBaseUrl}/domains/${this.domainId}/certificate`,
+    })
+      .then(function (payload) {
+        this.certificate = payload;
+        this.isCertificateLoading = false;
+      }.bind(this))
+      .catch(function () {
+        this.certificateError = "Failed to load certificate details.";
+        this.isCertificateLoading = false;
       }.bind(this));
   }
 

--- a/apps/web/src/views/domain.js
+++ b/apps/web/src/views/domain.js
@@ -1,5 +1,6 @@
 let m = require("mithril");
 let DomainModel = require("../models/domain");
+let { timestamp2LocalTime, timestamp2UtcTime } = require("../utils/date");
 
 class DomainView {
   constructor() {
@@ -81,6 +82,84 @@ class DomainView {
       m("i.fa.fa-question.text-muted.me-2", { title: "Unchecked" }),
       "Unchecked",
     ];
+  }
+
+  _certificateStatusText(status) {
+    if (!status) {
+      return "None";
+    }
+
+    return {
+      pending: "Pending",
+      active: "Active",
+      failed: "Failed",
+      expired: "Expired",
+    }[status] || status;
+  }
+
+  _certificateRow(label, value) {
+    return m(".d-flex.justify-content-between.border-bottom.py-2.small", [
+      m("span.text-muted", label),
+      m("span.text-end", value || "-"),
+    ]);
+  }
+
+  _certificatePanel() {
+    if (this.model.domainId === "new") {
+      return null;
+    }
+
+    let certificateStatus = this.model.domain
+      ? this.model.domain.certificateStatus
+      : null;
+
+    if (!certificateStatus) {
+      return m(".mt-4", [
+        m("h6.mb-3", "Certificate"),
+        this._certificateRow("Status", this._certificateStatusText(null)),
+      ]);
+    }
+
+    if (this.model.isCertificateLoading) {
+      return m(".mt-4", [
+        m("h6.mb-3", "Certificate"),
+        m("div", "Loading certificate..."),
+      ]);
+    }
+
+    if (this.model.certificateError) {
+      return m(".mt-4", [
+        m("h6.mb-3", "Certificate"),
+        m(".alert.alert-warning", this.model.certificateError),
+        this._certificateRow("Status", this._certificateStatusText(certificateStatus)),
+      ]);
+    }
+
+    if (!this.model.certificate) {
+      return m(".mt-4", [
+        m("h6.mb-3", "Certificate"),
+        this._certificateRow("Status", this._certificateStatusText(certificateStatus)),
+      ]);
+    }
+
+    let certificate = this.model.certificate;
+    return m(".mt-4", [
+      m("h6.mb-3", "Certificate"),
+      this._certificateRow("Status", this._certificateStatusText(certificate.status)),
+      this._certificateRow("CA", certificate.ca),
+      this._certificateRow("Validation method", certificate.validationMethod),
+      this._certificateRow("Expires (local)", timestamp2LocalTime(certificate.expiresAt)),
+      this._certificateRow("Expires (UTC)", timestamp2UtcTime(certificate.expiresAt)),
+      this._certificateRow("Last attempted (local)", timestamp2LocalTime(certificate.lastAttemptedAt)),
+      this._certificateRow("Last attempted (UTC)", timestamp2UtcTime(certificate.lastAttemptedAt)),
+      this._certificateRow("Last issued (local)", timestamp2LocalTime(certificate.lastIssuedAt)),
+      this._certificateRow("Last issued (UTC)", timestamp2UtcTime(certificate.lastIssuedAt)),
+      this._certificateRow("Last renewed (local)", timestamp2LocalTime(certificate.lastRenewedAt)),
+      this._certificateRow("Last renewed (UTC)", timestamp2UtcTime(certificate.lastRenewedAt)),
+      this._certificateRow("Next retry (local)", timestamp2LocalTime(certificate.nextRetryAt)),
+      this._certificateRow("Next retry (UTC)", timestamp2UtcTime(certificate.nextRetryAt)),
+      this._certificateRow("Failure reason", certificate.failureReason),
+    ]);
   }
 
   view() {
@@ -179,11 +258,8 @@ class DomainView {
         m(".col-12.col-xl-5", [
           m(".bg-light.rounded.h-100.p-4", [
             m("h6.mb-4", "Domain Status"),
-            m("label.form-label", { for: "domainARecord" }, "A Record"),
-            m(
-              "#domainARecord.form-control-plaintext",
-              this._aRecordBadge(),
-            ),
+            this._certificateRow("A Record", this._aRecordBadge()),
+            this._certificatePanel(),
           ]),
         ]),
       ]),

--- a/apps/web/src/views/domains.js
+++ b/apps/web/src/views/domains.js
@@ -39,6 +39,31 @@ class DomainsView {
         });
   }
 
+  _certificateBadge(domain) {
+    if (!domain.certificateStatus) {
+      return m("span.text-muted", "-");
+    }
+
+    let statusClasses = {
+      pending: "badge bg-secondary",
+      active: "badge bg-success",
+      failed: "badge bg-danger",
+      expired: "badge bg-danger",
+    };
+    let labels = {
+      pending: "Pending",
+      active: "Active",
+      failed: "Failed",
+      expired: "Expired",
+    };
+
+    return m(
+      "span",
+      { class: statusClasses[domain.certificateStatus] || "badge bg-secondary" },
+      labels[domain.certificateStatus] || domain.certificateStatus,
+    );
+  }
+
   _campaignBadge(domain) {
     if (domain.campaignName) {
       return domain.campaignName;
@@ -81,6 +106,7 @@ class DomainsView {
                           m("th", { scope: "col" }, "Purpose"),
                           m("th", { scope: "col" }, "Campaign"),
                           m("th", { scope: "col" }, "A Record"),
+                          m("th", { scope: "col" }, "Certificate"),
                           m("th", { scope: "col" }, "State"),
                         ]),
                       ),
@@ -90,7 +116,7 @@ class DomainsView {
                           ? m("tr", [
                               m(
                                 "td.text-center",
-                                { colspan: 6 },
+                                { colspan: 7 },
                                 "No domains found.",
                               ),
                             ])
@@ -109,6 +135,7 @@ class DomainsView {
                                   m("td", this._purposeBadge(domain)),
                                   m("td", this._campaignBadge(domain)),
                                   m("td", this._aRecordBadge(domain)),
+                                  m("td", this._certificateBadge(domain)),
                                   m("td", this._disabledBadge(domain)),
                                 ]);
                               }.bind(this),

--- a/infra/installer/install.sh
+++ b/infra/installer/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-BANGI_RELEASE_TAG="0.0.1a32"
+BANGI_RELEASE_TAG="0.0.1a33"
 BANGI_GITHUB_OWNER="devalentino"
 BANGI_GITHUB_REPO="bangi"
 BANGI_RAW_BASE_URL="https://raw.githubusercontent.com/${BANGI_GITHUB_OWNER}/${BANGI_GITHUB_REPO}/${BANGI_RELEASE_TAG}"

--- a/infra/installer/templates/compose.prod.yml
+++ b/infra/installer/templates/compose.prod.yml
@@ -1,6 +1,6 @@
 services:
   web:
-    image: ghcr.io/devalentino/bangi-web:0.0.1a32
+    image: ghcr.io/devalentino/bangi-web:0.0.1a33
     restart: always
     env_file:
       - /opt/bangi/shared/env/.env
@@ -10,7 +10,7 @@ services:
       - bangi
 
   api:
-    image: ghcr.io/devalentino/bangi-api:0.0.1a32
+    image: ghcr.io/devalentino/bangi-api:0.0.1a33
     restart: always
     env_file:
       - /opt/bangi/shared/env/.env


### PR DESCRIPTION
## Summary
- Adds certificate status to the managed domains list.
- Loads and displays certificate details on the managed domain detail page.
- Formats certificate timestamps with both local and UTC values and aligns Domain Status rows with the certificate table style.

## Scope
- Included: domain dashboard UI updates for certificate status/details, certificate response integration coverage, and staging API base URL config update.
- Not included: certificate issuance flow changes, DNS automation changes, database migrations, or backend certificate persistence changes.

## Risks
- Low UI risk. Domain detail now performs an additional certificate request only when a domain has a certificate status; failures render a warning without blocking the domain form.

## Links
- Jira: KAN-49
- Spec: TBD
