### PR TITLE
KAN-50: feat: show certificate diagnostics in health UI

### DIFF
--- a/apps/web/src/components/alerts_bell.js
+++ b/apps/web/src/components/alerts_bell.js
@@ -36,6 +36,15 @@ function alertIconClass(code) {
   }
 
   if (
+      code === "system_health_certificate_issuance_failed"
+      || code === "system_health_certificate_renewal_warning"
+      || code === "system_health_certificate_renewal_error"
+      || code === "system_health_certificate_expired"
+  ) {
+    return "fa fa-lock";
+  }
+
+  if (
       code === "facebook_pacs_business_portfolio_access_url_missing"
       || code === "facebook_pacs_business_portfolio_access_url_expiring_soon"
       || code === "facebook_pacs_business_portfolio_access_url_expired"

--- a/apps/web/src/config.js
+++ b/apps/web/src/config.js
@@ -4,7 +4,7 @@ if (typeof window !== "undefined" && window.APP_CONFIG) {
   runtimeConfig = window.APP_CONFIG;
 }
 
-var backendApiBaseUrl = "http://138.68.85.45/api/v2";
+var backendApiBaseUrl = "/api/v2";
 var debugPersistentAuth = runtimeConfig.DEBUG_PERSIST_AUTH === true
   || runtimeConfig.DEBUG_PERSIST_AUTH === "true";
 

--- a/apps/web/src/config.js
+++ b/apps/web/src/config.js
@@ -4,7 +4,7 @@ if (typeof window !== "undefined" && window.APP_CONFIG) {
   runtimeConfig = window.APP_CONFIG;
 }
 
-var backendApiBaseUrl = "http://159.65.117.52/api/v2";
+var backendApiBaseUrl = "http://138.68.85.45/api/v2";
 var debugPersistentAuth = runtimeConfig.DEBUG_PERSIST_AUTH === true
   || runtimeConfig.DEBUG_PERSIST_AUTH === "true";
 

--- a/apps/web/src/models/health.js
+++ b/apps/web/src/models/health.js
@@ -7,6 +7,8 @@ class HealthModel {
     this.history = [];
     this.nginxSnapshot = null;
     this.nginxError = null;
+    this.certificateDiagnostics = [];
+    this.certificateError = null;
     this.error = null;
     this.isLoading = false;
   }
@@ -18,6 +20,8 @@ class HealthModel {
     this.error = null;
     this.nginxSnapshot = null;
     this.nginxError = null;
+    this.certificateDiagnostics = [];
+    this.certificateError = null;
 
     let diskPromise = api
       .request({
@@ -58,7 +62,25 @@ class HealthModel {
         }.bind(this),
       );
 
-    return Promise.all([diskPromise, nginxPromise]).finally(
+    let certificatePromise = api
+      .request({
+        method: "GET",
+        url: `${config.backendApiBaseUrl}/health/certificates`,
+      })
+      .then(
+        function (payload) {
+          this.certificateDiagnostics = payload.content || [];
+          this.certificateError = null;
+        }.bind(this),
+      )
+      .catch(
+        function () {
+          this.certificateDiagnostics = [];
+          this.certificateError = "Failed to load certificate diagnostics.";
+        }.bind(this),
+      );
+
+    return Promise.all([diskPromise, nginxPromise, certificatePromise]).finally(
       function () {
         this.isLoading = false;
       }.bind(this),

--- a/apps/web/src/views/health.js
+++ b/apps/web/src/views/health.js
@@ -137,6 +137,97 @@ class HealthView {
     ]);
   }
 
+  _certificateStatusText(diagnostic) {
+    if (diagnostic.isARecordSet !== true) {
+      return "DNS not ready";
+    }
+
+    if (!diagnostic.status) {
+      return "No certificate";
+    }
+
+    const labels = {
+      pending: "Pending",
+      active: "Active",
+      failed: "Failed",
+      expired: "Expired",
+    };
+
+    return labels[diagnostic.status] || diagnostic.status;
+  }
+
+  _certificateStatusBadge(diagnostic) {
+    const badgeClasses = {
+      pending: "badge bg-info text-dark",
+      active: "badge bg-success",
+      failed: "badge bg-warning text-dark",
+      expired: "badge bg-danger",
+    };
+    const badgeClass = diagnostic.isARecordSet !== true
+      ? "badge bg-info text-dark"
+      : badgeClasses[diagnostic.status] || "badge bg-secondary";
+
+    return m(
+      "span",
+      { class: badgeClass },
+      this._certificateStatusText(diagnostic),
+    );
+  }
+
+  _aRecordIcon(diagnostic) {
+    return m("i.text-muted", {
+      class: diagnostic.isARecordSet ? "fa fa-check" : "fa fa-times",
+      title: diagnostic.isARecordSet ? "A record is set" : "A record is not set",
+    });
+  }
+
+  _certificateDiagnosticsPanel() {
+    return m(".col-sm-12", [
+      m(".bg-light.rounded.h-100.p-4", [
+        m(".d-flex.align-items-center.justify-content-between.mb-4", m("h6.mb-0", "Certificate Diagnostics")),
+        this.model.certificateError ? m(".alert.alert-danger.py-2.mb-4", this.model.certificateError) : null,
+        this.model.certificateDiagnostics.length === 0
+          ? m(".health-empty-state.py-5.text-center", [
+              m("i.fa.fa-lock.fa-2x.mb-3"),
+              m("h5.mb-2", "No Certificate Risks"),
+              m(".text-muted", "Enabled domains do not currently have certificate diagnostics to surface."),
+            ])
+          : m(
+              "div.table-responsive",
+              m("table.table.table-sm.health-certificate-table.align-middle.mb-0", [
+                m("thead", [
+                  m("tr", [
+                    m("th", { scope: "col" }, "Domain"),
+                    m("th", { scope: "col" }, "Certificate status"),
+                    m("th", { scope: "col" }, "A record"),
+                    m("th", { scope: "col" }, "Expires"),
+                    m("th", { scope: "col" }, "Last attempt"),
+                    m("th", { scope: "col" }, "Failures"),
+                    m("th", { scope: "col" }, "Failure"),
+                  ]),
+                ]),
+                m(
+                  "tbody",
+                  this.model.certificateDiagnostics.map(
+                    function (diagnostic) {
+                      return m("tr", [
+                        m("td", diagnostic.hostname),
+                        m("td", this._certificateStatusBadge(diagnostic)),
+                        m("td", this._aRecordIcon(diagnostic)),
+                        m("td", timestamp2LocalTime(diagnostic.expiresAt)),
+                        m("td", timestamp2LocalTime(diagnostic.lastAttemptedAt)),
+                        m("td", diagnostic.failureCount),
+                        m("td", diagnostic.failureReason || "-"),
+                      ]);
+                    }.bind(this),
+                  ),
+                ),
+              ]),
+            ),
+      ]),
+    ]);
+  }
+
   _usagePanel() {
     return m(".col-sm-12.col-xl-6", [
       m(".bg-light.rounded.h-100.p-4", [
@@ -238,14 +329,23 @@ class HealthView {
   view() {
     const hasDiskSummary = this.model.summary !== null;
     const hasNginxSnapshot = this.model.nginxSnapshot !== null || this.model.nginxError !== null;
+    const hasCertificateDiagnostics =
+      this.model.certificateDiagnostics.length > 0 || this.model.certificateError !== null;
 
     return m(".container-fluid.pt-4.px-4", [
       this.model.isLoading ? m(".bg-light.rounded.p-4.mb-4", "Loading system health...") : null,
       this.model.error ? m(".alert.alert-danger.mb-4", this.model.error) : null,
       hasDiskSummary
-        ? m("div", [m(".row.g-4", [this._usagePanel(), this._nginxPanel()]), m(".row.g-4.mt-0", [this._historyPanel()])])
+        ? m("div", [
+            m(".row.g-4", [this._usagePanel(), this._nginxPanel()]),
+            m(".row.g-4.mt-0", [this._certificateDiagnosticsPanel()]),
+            m(".row.g-4.mt-0", [this._historyPanel()]),
+          ])
         : null,
       !hasDiskSummary && hasNginxSnapshot ? m(".row.g-4", [this._nginxPanel()]) : null,
+      !hasDiskSummary && !hasNginxSnapshot && hasCertificateDiagnostics
+        ? m(".row.g-4", [this._certificateDiagnosticsPanel()])
+        : null,
     ]);
   }
 }

--- a/apps/web/styles/app.css
+++ b/apps/web/styles/app.css
@@ -63,3 +63,7 @@
 .alerts-dropdown-item:last-child {
   border-bottom: 0 !important;
 }
+
+.health-certificate-table {
+  font-size: 12px;
+}

--- a/infra/installer/install.sh
+++ b/infra/installer/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-BANGI_RELEASE_TAG="0.0.1a35"
+BANGI_RELEASE_TAG="0.0.1a36"
 BANGI_GITHUB_OWNER="devalentino"
 BANGI_GITHUB_REPO="bangi"
 BANGI_RAW_BASE_URL="https://raw.githubusercontent.com/${BANGI_GITHUB_OWNER}/${BANGI_GITHUB_REPO}/${BANGI_RELEASE_TAG}"

--- a/infra/installer/templates/compose.prod.yml
+++ b/infra/installer/templates/compose.prod.yml
@@ -1,6 +1,6 @@
 services:
   web:
-    image: ghcr.io/devalentino/bangi-web:0.0.1a35
+    image: ghcr.io/devalentino/bangi-web:0.0.1a36
     restart: always
     env_file:
       - /opt/bangi/shared/env/.env
@@ -10,7 +10,7 @@ services:
       - bangi
 
   api:
-    image: ghcr.io/devalentino/bangi-api:0.0.1a35
+    image: ghcr.io/devalentino/bangi-api:0.0.1a36
     restart: always
     env_file:
       - /opt/bangi/shared/env/.env


### PR DESCRIPTION
## Summary
- Adds certificate diagnostics loading to the health page and renders certificate risk rows with compact status badges, A-record icons, timestamps, failure counts, and failure reasons.
- Adds certificate alert icon handling in the alerts dropdown.
- Updates the frontend default backend API base URL.

## Scope
- Included: web health page certificate diagnostics UI, alerts bell certificate icon mapping, small certificate diagnostics table styling, and frontend API base URL update.
- Not included: backend certificate diagnostics/alert logic, certificate worker behavior, ACME wrappers, or certificate mutation endpoints.

## Risks
- Low-to-medium: the health view now depends on `/health/certificates`; if the endpoint is unavailable, the page shows a certificate diagnostics load error while preserving other health panels.

## Links
- Jira: https://bangitech.atlassian.net/browse/KAN-50
- Spec: https://bangitech.atlassian.net/wiki/spaces/SD/pages/10977282/Managed+HTTPS+Certificates+-+Technical+Spec
