### PR TITLE
KAN-52: feat: show failed Nginx validation alert

### DIFF
--- a/apps/api/src/alerts/enums.py
+++ b/apps/api/src/alerts/enums.py
@@ -16,6 +16,7 @@ class AlertCode(StrEnum):
     SYSTEM_HEALTH_CERTIFICATE_RENEWAL_WARNING = 'system_health_certificate_renewal_warning'
     SYSTEM_HEALTH_CERTIFICATE_RENEWAL_ERROR = 'system_health_certificate_renewal_error'
     SYSTEM_HEALTH_CERTIFICATE_EXPIRED = 'system_health_certificate_expired'
+    SYSTEM_HEALTH_NGINX_VALIDATION_FAILED = 'system_health_nginx_validation_failed'
 
 
 class AlertSeverity(StrEnum):

--- a/apps/api/src/health/alerts.py
+++ b/apps/api/src/health/alerts.py
@@ -52,3 +52,31 @@ def collect_disk_utilization_alerts(container):
         ]
 
     return []
+
+
+@register_alert_callback
+def collect_nginx_validation_alerts(container):
+    snapshot = container.get(HealthService).latest_nginx_validation_snapshot()
+
+    if snapshot is None or snapshot.validation_status != 'failed':
+        return []
+
+    validation_timestamp = int(snapshot.created_at.timestamp())
+    message = 'Latest Nginx validation failed.'
+    if snapshot.domain_id is not None:
+        message = f'Latest Nginx validation failed for domain {snapshot.domain_id}.'
+    if snapshot.validation_error:
+        message = f'{message} {snapshot.validation_error}'
+
+    return [
+        Alert(
+            code=AlertCode.SYSTEM_HEALTH_NGINX_VALIDATION_FAILED,
+            severity=AlertSeverity.ERROR,
+            message=message,
+            payload={
+                'domainId': snapshot.domain_id,
+                'validationTimestamp': validation_timestamp,
+                'validationError': snapshot.validation_error,
+            },
+        )
+    ]

--- a/apps/api/tests/integration/test_health.py
+++ b/apps/api/tests/integration/test_health.py
@@ -922,3 +922,81 @@ class TestNginxValidationHealth:
                 ],
             }
         }
+
+    def test_returns_error_alert_when_latest_nginx_validation_snapshot_failed(
+        self, client, authorization, write_to_db, timestamp
+    ):
+        failed_snapshot = write_to_db(
+            'health_nginx_validation_snapshot',
+            {
+                'created_at': timestamp - 10,
+                'domain_id': 9,
+                'validation_status': 'failed',
+                'validation_error': 'nginx: [emerg] invalid number of arguments',
+                'sites_available_files': [
+                    'sites-available/example.com/20260510T010101Z-abc12345.conf',
+                    'sites-available/example.com/20260510T010202Z-def67890.conf',
+                ],
+                'sites_enabled_refs': [
+                    'sites-enabled/example.com.conf -> ../sites-available/example.com/20260510T010202Z-def67890.conf'
+                ],
+            },
+        )
+
+        response = client.get('/api/v2/alerts', headers={'Authorization': authorization})
+
+        assert response.status_code == 200, response.text
+        assert response.json == {
+            'content': [
+                {
+                    'code': 'system_health_nginx_validation_failed',
+                    'message': (
+                        'Latest Nginx validation failed for domain 9. ' 'nginx: [emerg] invalid number of arguments'
+                    ),
+                    'severity': 'error',
+                    'source': 'src.health.alerts',
+                    'payload': {
+                        'domainId': failed_snapshot['domain_id'],
+                        'validationTimestamp': failed_snapshot['created_at'],
+                        'validationError': failed_snapshot['validation_error'],
+                    },
+                }
+            ]
+        }
+
+    def test_returns_no_nginx_validation_alert_when_latest_snapshot_succeeded(
+        self, client, authorization, write_to_db, timestamp
+    ):
+        write_to_db(
+            'health_nginx_validation_snapshot',
+            {
+                'created_at': timestamp - 120,
+                'domain_id': 9,
+                'validation_status': 'failed',
+                'validation_error': 'nginx: [emerg] bad config',
+                'sites_available_files': ['sites-available/example.com/old.conf'],
+                'sites_enabled_refs': ['sites-enabled/example.com.conf -> ../sites-available/example.com/old.conf'],
+            },
+        )
+        write_to_db(
+            'health_nginx_validation_snapshot',
+            {
+                'created_at': timestamp - 10,
+                'domain_id': 9,
+                'validation_status': 'success',
+                'validation_error': None,
+                'sites_available_files': ['sites-available/example.com/current.conf'],
+                'sites_enabled_refs': ['sites-enabled/example.com.conf -> ../sites-available/example.com/current.conf'],
+            },
+        )
+
+        response = client.get('/api/v2/alerts', headers={'Authorization': authorization})
+
+        assert response.status_code == 200, response.text
+        assert response.json == {'content': []}
+
+    def test_returns_no_nginx_validation_alert_when_no_snapshot_exists(self, client, authorization):
+        response = client.get('/api/v2/alerts', headers={'Authorization': authorization})
+
+        assert response.status_code == 200, response.text
+        assert response.json == {'content': []}

--- a/apps/web/src/components/alerts_bell.js
+++ b/apps/web/src/components/alerts_bell.js
@@ -44,6 +44,10 @@ function alertIconClass(code) {
     return "fa fa-lock";
   }
 
+  if (code === "system_health_nginx_validation_failed") {
+    return "fa fa-server";
+  }
+
   if (
       code === "facebook_pacs_business_portfolio_access_url_missing"
       || code === "facebook_pacs_business_portfolio_access_url_expiring_soon"

--- a/infra/installer/install.sh
+++ b/infra/installer/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-BANGI_RELEASE_TAG="0.0.1a36"
+BANGI_RELEASE_TAG="0.0.1a37"
 BANGI_GITHUB_OWNER="devalentino"
 BANGI_GITHUB_REPO="bangi"
 BANGI_RAW_BASE_URL="https://raw.githubusercontent.com/${BANGI_GITHUB_OWNER}/${BANGI_GITHUB_REPO}/${BANGI_RELEASE_TAG}"

--- a/infra/installer/templates/compose.prod.yml
+++ b/infra/installer/templates/compose.prod.yml
@@ -1,6 +1,6 @@
 services:
   web:
-    image: ghcr.io/devalentino/bangi-web:0.0.1a36
+    image: ghcr.io/devalentino/bangi-web:0.0.1a37
     restart: always
     env_file:
       - /opt/bangi/shared/env/.env
@@ -10,7 +10,7 @@ services:
       - bangi
 
   api:
-    image: ghcr.io/devalentino/bangi-api:0.0.1a36
+    image: ghcr.io/devalentino/bangi-api:0.0.1a37
     restart: always
     env_file:
       - /opt/bangi/shared/env/.env


### PR DESCRIPTION
## Summary
- Adds a global alert when the latest Nginx validation snapshot has failed.
- Includes an error-severity alert payload with domain ID, validation timestamp, and validation error so operators can inspect details on the Health page.
- Maps the new alert code to a server icon in the web alert bell.
- Adds integration coverage for failed, successful, and missing Nginx validation snapshots.

## Scope
- Included: backend alert code and callback, `/api/v2/alerts` integration tests, web alert bell icon mapping.
- Not included: Health page behavior changes, Nginx validation persistence changes, or exposing Nginx file/reference details in the alert payload.

## Risks
- Low risk. The callback is read-only and only emits an alert when the latest persisted snapshot explicitly reports `failed`.

## Links
- Jira: https://bangitech.atlassian.net/browse/KAN-52
- Spec: https://bangitech.atlassian.net/wiki/spaces/SD/pages/622593/Discard+Alerts+-+Technical+Spec
