### PR TITLE
KAN-56: feat: add show-once flow selection for repeat visitors

### DIFF
--- a/apps/api/migrations/012_flow_show_once_per_visitor.py
+++ b/apps/api/migrations/012_flow_show_once_per_visitor.py
@@ -13,10 +13,7 @@ with suppress(ImportError):
 def migrate(migrator: Migrator, database: pw.Database, *, fake=False):
     """Write your migrations here."""
 
-    migrator.add_fields(
-        'flow',
-        show_once_per_visitor=pw.BooleanField(default=False),
-    )
+    migrator.sql('ALTER TABLE flow ADD COLUMN show_once_per_visitor BOOLEAN NOT NULL DEFAULT FALSE')
 
 
 def rollback(migrator: Migrator, database: pw.Database, *, fake=False):

--- a/apps/api/migrations/012_flow_show_once_per_visitor.py
+++ b/apps/api/migrations/012_flow_show_once_per_visitor.py
@@ -1,0 +1,25 @@
+"""Peewee migrations -- 012_flow_show_once_per_visitor.py."""
+
+from contextlib import suppress
+
+import peewee as pw
+from peewee_migrate import Migrator
+
+
+with suppress(ImportError):
+    import playhouse.postgres_ext as pw_pext
+
+
+def migrate(migrator: Migrator, database: pw.Database, *, fake=False):
+    """Write your migrations here."""
+
+    migrator.add_fields(
+        'flow',
+        show_once_per_visitor=pw.BooleanField(default=False),
+    )
+
+
+def rollback(migrator: Migrator, database: pw.Database, *, fake=False):
+    """Write your rollback migrations here."""
+
+    migrator.remove_fields('flow', 'show_once_per_visitor')

--- a/apps/api/src/core/entities.py
+++ b/apps/api/src/core/entities.py
@@ -58,3 +58,4 @@ class Flow(Entity):
     redirect_url = CharField(null=True)
     is_enabled = BooleanField(default=True)
     is_deleted = BooleanField(default=False)
+    show_once_per_visitor = BooleanField(default=False)

--- a/apps/api/src/core/routes.py
+++ b/apps/api/src/core/routes.py
@@ -182,6 +182,7 @@ class CampaignFlows(MethodView):
             flow_payload['actionType'],
             flow_payload.get('redirectUrl'),
             flow_payload.get('isEnabled', True),
+            flow_payload.get('showOncePerVisitor', False),
             landing_archive,
         )
 
@@ -230,6 +231,7 @@ class Flow(MethodView):
             flow_payload.get('actionType'),
             flow_payload.get('redirectUrl'),
             flow_payload.get('isEnabled'),
+            flow_payload.get('showOncePerVisitor'),
             landing_archive,
         )
 

--- a/apps/api/src/core/schemas.py
+++ b/apps/api/src/core/schemas.py
@@ -133,6 +133,7 @@ class FlowUpdateRequestSchema(Schema):
     actionType = fields.Enum(FlowActionType, required=True)
     redirectUrl = fields.Url(allow_none=True, load_default=None)
     isEnabled = fields.Boolean()
+    showOncePerVisitor = fields.Boolean(required=True)
 
     @validates_schema
     def validate_action(self, data, **kwargs):
@@ -186,6 +187,7 @@ class FlowResponseSchema(Schema):
     redirectUrl = fields.String(allow_none=True)
     landingPath = fields.String(allow_none=True)
     isEnabled = fields.Boolean(required=True)
+    showOncePerVisitor = fields.Boolean(required=True)
     rule = fields.String(required=True, allow_none=True)
 
 

--- a/apps/api/src/core/services.py
+++ b/apps/api/src/core/services.py
@@ -254,6 +254,7 @@ class FlowService:
         action_type,
         redirect_url=None,
         is_enabled=True,
+        show_once_per_visitor=False,
         landing_archive=None,
     ):
         flow = Flow(
@@ -264,6 +265,7 @@ class FlowService:
             action_type=action_type,
             redirect_url=redirect_url,
             is_enabled=is_enabled,
+            show_once_per_visitor=show_once_per_visitor,
         )
         flow.save()
 
@@ -281,6 +283,7 @@ class FlowService:
         action_type=None,
         redirect_url=None,
         is_enabled=None,
+        show_once_per_visitor=None,
         landing_archive=None,
     ):
         flow = self.get(flow_id, campaign_id)
@@ -298,6 +301,9 @@ class FlowService:
 
         if is_enabled is not None:
             flow.is_enabled = is_enabled
+
+        if show_once_per_visitor is not None:
+            flow.show_once_per_visitor = show_once_per_visitor
 
         flow.save()
         return flow
@@ -322,23 +328,42 @@ class FlowService:
             Flow.select(fn.count(Flow.id)).where((Flow.is_deleted == False) & (Flow.campaign == campaign_id)).scalar()
         )
 
-    def process_flows(self, campaign_id: int, client: Client, cookie_value=None):
-        flows = (
+    def process_flows(self, campaign_id: int, client: Client, current_flow_id=None):
+        flows = list(
             Flow.select()
             .where((Flow.campaign_id == campaign_id) & (Flow.is_enabled == True) & (Flow.is_deleted == False))
             .order_by(Flow.order_value.desc(), Flow.id.asc())
         )
+        current_index = None
+
+        if current_flow_id is not None:
+            for index, flow in enumerate(flows):
+                if flow.id == current_flow_id:
+                    current_index = index
+                    break
 
         matched_flow = None
-        for flow in flows:
-            if flow.rule is None:
-                matched_flow = flow
-                break
+        if current_index is not None:
+            current_flow = flows[current_index]
+            if not current_flow.show_once_per_visitor:
+                if current_flow.rule is None:
+                    matched_flow = current_flow
+                else:
+                    rule = rule_engine.Rule(current_flow.rule, context=Client.rule_engine_context())
+                    if rule.matches(dataclasses.asdict(client)):
+                        matched_flow = current_flow
 
-            rule = rule_engine.Rule(flow.rule, context=Client.rule_engine_context())
-            if rule.matches(dataclasses.asdict(client)):
-                matched_flow = flow
-                break
+        if matched_flow is None:
+            start_index = current_index + 1 if current_index is not None else 0
+            for flow in flows[start_index:]:
+                if flow.rule is None:
+                    matched_flow = flow
+                    break
+
+                rule = rule_engine.Rule(flow.rule, context=Client.rule_engine_context())
+                if rule.matches(dataclasses.asdict(client)):
+                    matched_flow = flow
+                    break
 
         if matched_flow is None:
             logger.warning(

--- a/apps/api/src/tracker/routes.py
+++ b/apps/api/src/tracker/routes.py
@@ -11,6 +11,7 @@ from src.domains.enums import DomainCookieName
 from src.domains.services import DomainCookieService, DomainService
 from src.tracker.schemas import (
     TrackClickRequestSchema,
+    TrackCurrentFlowCookieSchema,
     TrackLeadRequestSchema,
     TrackPostbackRequestSchema,
     TrackProcessRequestSchema,
@@ -90,8 +91,10 @@ class Process(MethodView):
             request.user_agent.string, request.environ.get('HTTP_X_REAL_IP', request.remote_addr)
         )
         cookie_name = cookie_service.get_or_create_opaque_name(domain.id, DomainCookieName.flow_id)
-        cookie_value = request.cookies.get(cookie_name)
-        action_type, subject, flow_id = flow_service.process_flows(campaignId, client, cookie_value)
+        current_flow_payload = TrackCurrentFlowCookieSchema().load({'currentFlowId': request.cookies.get(cookie_name)})
+        action_type, subject, flow_id = flow_service.process_flows(
+            campaignId, client, current_flow_payload['currentFlowId']
+        )
 
         if action_type == FlowActionType.redirect:
             response = redirect(subject)

--- a/apps/api/src/tracker/schemas.py
+++ b/apps/api/src/tracker/schemas.py
@@ -1,4 +1,4 @@
-from marshmallow import INCLUDE, fields
+from marshmallow import INCLUDE, fields, pre_load
 
 from src.core.schemas import Schema
 
@@ -30,3 +30,20 @@ class TrackProcessRequestSchema(Schema):
 
     class Meta:
         unknown = INCLUDE
+
+
+class TrackCurrentFlowCookieSchema(Schema):
+    currentFlowId = fields.Integer(allow_none=True, load_default=None)
+
+    @pre_load
+    def normalize_current_flow_id(self, data, **kwargs):
+        current_flow_id = data.get('currentFlowId')
+        if current_flow_id is None:
+            return data
+
+        try:
+            data['currentFlowId'] = int(current_flow_id)
+        except (TypeError, ValueError):
+            data['currentFlowId'] = None
+
+        return data

--- a/apps/api/tests/fixtures/payloads.py
+++ b/apps/api/tests/fixtures/payloads.py
@@ -61,4 +61,5 @@ def flow_payload(flow_name, flow_rule, flow_is_deleted):
         'redirect_url': 'https://example.com',
         'is_enabled': True,
         'is_deleted': flow_is_deleted,
+        'show_once_per_visitor': False,
     }

--- a/apps/api/tests/integration/core/test_flows.py
+++ b/apps/api/tests/integration/core/test_flows.py
@@ -62,6 +62,7 @@ def test_flows_list(client, authorization, campaign, flow_rule, write_to_db):
                 'redirect_url': f'https://example.com/{index}',
                 'is_enabled': True,
                 'is_deleted': False,
+                'show_once_per_visitor': False,
             },
         )
 
@@ -84,6 +85,7 @@ def test_flows_list(client, authorization, campaign, flow_rule, write_to_db):
                 'redirectUrl': f'https://example.com/{index}',
                 'landingPath': None,
                 'isEnabled': True,
+                'showOncePerVisitor': False,
             }
             for index in range(20)
         ],
@@ -104,6 +106,7 @@ def test_flows_list__filters_by_campaign(client, authorization, campaign, campai
                 'redirect_url': f'https://example.com/{index}',
                 'is_enabled': True,
                 'is_deleted': False,
+                'show_once_per_visitor': False,
             },
         )
 
@@ -120,6 +123,7 @@ def test_flows_list__filters_by_campaign(client, authorization, campaign, campai
                 'redirect_url': f'https://example.com/other/{index}',
                 'is_enabled': True,
                 'is_deleted': False,
+                'show_once_per_visitor': False,
             },
         )
 
@@ -142,6 +146,7 @@ def test_flows_list__filters_by_campaign(client, authorization, campaign, campai
                 'redirectUrl': f'https://example.com/{index}',
                 'landingPath': None,
                 'isEnabled': True,
+                'showOncePerVisitor': False,
             }
             for index in range(3)
         ],
@@ -161,6 +166,7 @@ def test_flows_list__ordered_by_order_value_desc(client, authorization, campaign
             'redirect_url': 'https://example.com/a',
             'is_enabled': True,
             'is_deleted': False,
+            'show_once_per_visitor': False,
         },
     )
     second = write_to_db(
@@ -174,6 +180,7 @@ def test_flows_list__ordered_by_order_value_desc(client, authorization, campaign
             'redirect_url': 'https://example.com/b',
             'is_enabled': True,
             'is_deleted': False,
+            'show_once_per_visitor': False,
         },
     )
     third = write_to_db(
@@ -187,6 +194,7 @@ def test_flows_list__ordered_by_order_value_desc(client, authorization, campaign
             'redirect_url': 'https://example.com/c',
             'is_enabled': True,
             'is_deleted': False,
+            'show_once_per_visitor': False,
         },
     )
 
@@ -209,6 +217,7 @@ def test_flows_list__ordered_by_order_value_desc(client, authorization, campaign
                 'redirectUrl': third['redirect_url'],
                 'landingPath': mock.ANY,
                 'isEnabled': third['is_enabled'],
+                'showOncePerVisitor': False,
             },
             {
                 'id': first['id'],
@@ -221,6 +230,7 @@ def test_flows_list__ordered_by_order_value_desc(client, authorization, campaign
                 'redirectUrl': first['redirect_url'],
                 'landingPath': mock.ANY,
                 'isEnabled': first['is_enabled'],
+                'showOncePerVisitor': False,
             },
             {
                 'id': second['id'],
@@ -233,6 +243,7 @@ def test_flows_list__ordered_by_order_value_desc(client, authorization, campaign
                 'redirectUrl': second['redirect_url'],
                 'landingPath': mock.ANY,
                 'isEnabled': second['is_enabled'],
+                'showOncePerVisitor': False,
             },
         ],
         'pagination': {'page': 1, 'pageSize': 20, 'sortBy': 'orderValue', 'sortOrder': 'desc', 'total': 3},
@@ -252,6 +263,7 @@ def test_flows_list__filter_out_deleted(client, authorization, campaign, flow_ru
                 'redirect_url': f'https://example.com/{index}',
                 'is_enabled': True,
                 'is_deleted': True,
+                'show_once_per_visitor': False,
             },
         )
 
@@ -285,6 +297,7 @@ def test_get_flow(client, authorization, campaign, flow):
         'redirectUrl': flow['redirect_url'],
         'landingPath': None,
         'isEnabled': bool(flow['is_enabled']),
+        'showOncePerVisitor': False,
     }
 
 
@@ -327,6 +340,7 @@ def test_create_flow__redirect_action_success(client, authorization, campaign, r
         'actionType': 'redirect',
         'redirectUrl': 'https://example.com',
         'isEnabled': True,
+        'showOncePerVisitor': False,
     }
 
     response = client.post(
@@ -350,7 +364,29 @@ def test_create_flow__redirect_action_success(client, authorization, campaign, r
         'redirect_url': request_payload['redirectUrl'],
         'is_enabled': request_payload['isEnabled'],
         'is_deleted': False,
+        'show_once_per_visitor': False,
     }
+
+
+def test_create_flow__stores_show_once_per_visitor(client, authorization, campaign, read_from_db):
+    request_payload = {
+        'name': 'Show-once flow',
+        'rule': None,
+        'actionType': 'redirect',
+        'redirectUrl': 'https://example.com/show-once',
+        'isEnabled': True,
+        'showOncePerVisitor': True,
+    }
+
+    response = client.post(
+        f'/api/v2/core/campaigns/{campaign["id"]}/flows',
+        headers={'Authorization': authorization},
+        data=request_payload,
+        content_type='multipart/form-data',
+    )
+
+    assert response.status_code == 201, response.text
+    assert read_from_db('flow')['show_once_per_visitor'] == 1
 
 
 def test_create_flow__without_rule(client, authorization, campaign, read_from_db):
@@ -359,6 +395,7 @@ def test_create_flow__without_rule(client, authorization, campaign, read_from_db
         'actionType': 'redirect',
         'redirectUrl': 'https://example.com',
         'isEnabled': True,
+        'showOncePerVisitor': False,
     }
 
     response = client.post(
@@ -382,6 +419,7 @@ def test_create_flow__render_action_success(
         'actionType': 'render',
         'landingArchive': (_zip_bytes(), 'landing.zip'),
         'rule': flow_rule,
+        'showOncePerVisitor': False,
     }
 
     response = client.post(
@@ -406,6 +444,7 @@ def test_create_flow__render_action_success(
         'redirect_url': None,
         'is_enabled': 1,
         'is_deleted': 0,
+        'show_once_per_visitor': False,
     }
     assert (pathlib.Path(expected_landing_path) / 'index.html').exists()
 
@@ -418,6 +457,7 @@ def test_create_flow__render_action_success_with_nested_archive(
         'actionType': 'render',
         'landingArchive': (_zip_bytes_with_assets(), 'landing.zip'),
         'rule': flow_rule,
+        'showOncePerVisitor': False,
     }
 
     response = client.post(
@@ -444,6 +484,7 @@ def test_create_flow__requires_redirect_url_for_redirect_action(client, authoriz
             'name': flow_name,
             'actionType': 'redirect',
             'rule': flow_rule,
+            'showOncePerVisitor': False,
         },
         content_type='multipart/form-data',
     )
@@ -465,6 +506,7 @@ def test_create_flow__requires_landing_archive_for_render_action(client, authori
             'rule': flow_rule,
             'actionType': 'render',
             'redirectUrl': 'https://example.com',
+            'showOncePerVisitor': False,
         },
         content_type='multipart/form-data',
     )
@@ -486,6 +528,7 @@ def test_create_flow__rejects_non_zip_landing_archive(client, authorization, cam
             'rule': flow_rule,
             'actionType': 'render',
             'landingArchive': (io.BytesIO(b'not-a-zip'), 'landing.txt'),
+            'showOncePerVisitor': False,
         },
         content_type='multipart/form-data',
     )
@@ -506,6 +549,7 @@ def test_create_flow__rejects_landing_archive_without_index(
         'actionType': 'render',
         'landingArchive': (_zip_bytes_without_index(), 'landing.zip'),
         'rule': flow_rule,
+        'showOncePerVisitor': False,
     }
 
     response = client.post(
@@ -526,6 +570,7 @@ def test_create_flow__rejects_rule_with_unsupported_term(client, authorization, 
         'actionType': 'redirect',
         'redirectUrl': 'https://example.com',
         'isEnabled': True,
+        'showOncePerVisitor': False,
     }
 
     response = client.post(
@@ -554,6 +599,7 @@ def test_create_flow__rejects_blank_rule_variations(client, authorization, campa
             'actionType': 'redirect',
             'redirectUrl': 'https://example.com',
             'isEnabled': True,
+            'showOncePerVisitor': False,
         },
         content_type='multipart/form-data',
     )
@@ -573,6 +619,7 @@ def test_update_flow__redirect_action_success(client, authorization, flow, read_
         'actionType': 'redirect',
         'redirectUrl': 'https://example.org',
         'isEnabled': False,
+        'showOncePerVisitor': False,
     }
 
     response = client.patch(
@@ -596,6 +643,7 @@ def test_update_flow__redirect_action_success(client, authorization, flow, read_
         'redirect_url': request_payload['redirectUrl'],
         'is_enabled': request_payload['isEnabled'],
         'is_deleted': False,
+        'show_once_per_visitor': False,
     }
 
 
@@ -608,6 +656,7 @@ def test_update_flow__rejects_blank_rule_variations(client, authorization, flow,
             'rule': input_rule,
             'actionType': 'redirect',
             'redirectUrl': 'https://example.org',
+            'showOncePerVisitor': False,
         },
         content_type='multipart/form-data',
     )
@@ -630,6 +679,7 @@ def test_update_flow__without_rule_clears_rule(client, authorization, flow, read
             'actionType': 'redirect',
             'redirectUrl': 'https://example.org',
             'isEnabled': False,
+            'showOncePerVisitor': False,
         },
         content_type='multipart/form-data',
     )
@@ -652,6 +702,7 @@ def test_get_flow__without_rule(client, authorization, campaign, write_to_db):
             'redirect_url': 'https://example.com/no-rule',
             'is_enabled': True,
             'is_deleted': False,
+            'show_once_per_visitor': False,
         },
     )
 
@@ -672,7 +723,66 @@ def test_get_flow__without_rule(client, authorization, campaign, write_to_db):
         'redirectUrl': flow['redirect_url'],
         'landingPath': None,
         'isEnabled': bool(flow['is_enabled']),
+        'showOncePerVisitor': False,
     }
+
+
+def test_get_flow__returns_show_once_per_visitor(client, authorization, campaign, write_to_db):
+    flow = write_to_db(
+        'flow',
+        {
+            'name': 'Show-once flow',
+            'campaign_id': campaign['id'],
+            'rule': None,
+            'order_value': 1,
+            'action_type': 'redirect',
+            'redirect_url': 'https://example.com/show-once',
+            'is_enabled': True,
+            'is_deleted': False,
+            'show_once_per_visitor': True,
+        },
+    )
+
+    response = client.get(
+        f'/api/v2/core/campaigns/{campaign["id"]}/flows/{flow["id"]}',
+        headers={'Authorization': authorization},
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json == {
+        'id': flow['id'],
+        'name': flow['name'],
+        'campaignId': flow['campaign_id'],
+        'campaignName': campaign['name'],
+        'rule': None,
+        'orderValue': flow['order_value'],
+        'actionType': flow['action_type'],
+        'redirectUrl': flow['redirect_url'],
+        'landingPath': None,
+        'isEnabled': True,
+        'showOncePerVisitor': True,
+    }
+
+
+def test_update_flow__stores_show_once_per_visitor(client, authorization, flow, read_from_db):
+    request_payload = {
+        'name': flow['name'],
+        'rule': flow['rule'],
+        'actionType': 'redirect',
+        'redirectUrl': 'https://example.org',
+        'isEnabled': True,
+        'showOncePerVisitor': True,
+    }
+
+    response = client.patch(
+        f'/api/v2/core/campaigns/{flow["campaign_id"]}/flows/{flow["id"]}',
+        headers={'Authorization': authorization},
+        data=request_payload,
+        content_type='multipart/form-data',
+    )
+
+    assert response.status_code == 200, response.text
+    assert read_from_db('flow', filters={'id': flow['id']})['show_once_per_visitor'] == 1
 
 
 def test_update_flow__render_action_success(
@@ -684,6 +794,7 @@ def test_update_flow__render_action_success(
         'actionType': 'render',
         'isEnabled': True,
         'landingArchive': (_zip_bytes(), 'landing.zip'),
+        'showOncePerVisitor': False,
     }
 
     response = client.patch(
@@ -708,6 +819,7 @@ def test_update_flow__render_action_success(
         'redirect_url': None,
         'is_enabled': request_payload['isEnabled'],
         'is_deleted': False,
+        'show_once_per_visitor': False,
     }
     assert (pathlib.Path(expected_landing_path) / 'index.html').exists()
 
@@ -719,6 +831,7 @@ def test_update_flow__requires_redirect_url_for_redirect_action(client, authoriz
         data={
             'actionType': 'redirect',
             'rule': flow['rule'],
+            'showOncePerVisitor': False,
         },
         content_type='multipart/form-data',
     )
@@ -735,7 +848,7 @@ def test_update_flow__requires_landing_archive_for_render_action(client, authori
     response = client.patch(
         f'/api/v2/core/campaigns/{flow["campaign_id"]}/flows/{flow["id"]}',
         headers={'Authorization': authorization},
-        data={'actionType': 'render', 'rule': flow['rule']},
+        data={'actionType': 'render', 'rule': flow['rule'], 'showOncePerVisitor': False},
         content_type='multipart/form-data',
     )
 
@@ -755,6 +868,7 @@ def test_update_flow__rejects_non_zip_landing_archive(client, authorization, flo
             'rule': flow['rule'],
             'actionType': 'render',
             'landingArchive': (io.BytesIO(b'not-a-zip'), 'landing.txt'),
+            'showOncePerVisitor': False,
         },
         content_type='multipart/form-data',
     )
@@ -775,6 +889,7 @@ def test_update_flow__rejects_unsupported_rule_term(client, authorization, flow)
             'rule': 'country ==',
             'actionType': 'redirect',
             'redirectUrl': 'https://example.org',
+            'showOncePerVisitor': False,
         },
         content_type='multipart/form-data',
     )
@@ -801,6 +916,7 @@ def test_bulk_update_flow_order_values(
             'redirect_url': 'https://example.com/1',
             'is_enabled': True,
             'is_deleted': False,
+            'show_once_per_visitor': False,
         },
     )
     flow_two = write_to_db(
@@ -814,6 +930,7 @@ def test_bulk_update_flow_order_values(
             'redirect_url': 'https://example.com/2',
             'is_enabled': True,
             'is_deleted': False,
+            'show_once_per_visitor': False,
         },
     )
     flow_three = write_to_db(
@@ -827,6 +944,7 @@ def test_bulk_update_flow_order_values(
             'redirect_url': 'https://example.com/3',
             'is_enabled': True,
             'is_deleted': False,
+            'show_once_per_visitor': False,
         },
     )
     other_campaign = write_to_db('campaign', campaign_payload | {'name': 'Other Campaign'})
@@ -841,6 +959,7 @@ def test_bulk_update_flow_order_values(
             'redirect_url': 'https://example.com/other',
             'is_enabled': True,
             'is_deleted': False,
+            'show_once_per_visitor': False,
         },
     )
 

--- a/apps/api/tests/integration/core/test_flows.py
+++ b/apps/api/tests/integration/core/test_flows.py
@@ -371,7 +371,6 @@ def test_create_flow__redirect_action_success(client, authorization, campaign, r
 def test_create_flow__stores_show_once_per_visitor(client, authorization, campaign, read_from_db):
     request_payload = {
         'name': 'Show-once flow',
-        'rule': None,
         'actionType': 'redirect',
         'redirectUrl': 'https://example.com/show-once',
         'isEnabled': True,

--- a/apps/api/tests/integration/track/test_process.py
+++ b/apps/api/tests/integration/track/test_process.py
@@ -27,6 +27,227 @@ def ip2location_mock(environment):
 
 
 class TestTrackRedirect:
+    def test_track_redirect__evaluates_current_flow_first_when_cookie_flow_is_valid(
+        self, client, campaign, domain, write_to_db, ip2location_mock
+    ):
+        write_to_db(
+            'flow',
+            {
+                'name': 'Higher priority fallback',
+                'campaign_id': campaign['id'],
+                'rule': None,
+                'order_value': 20,
+                'action_type': 'redirect',
+                'redirect_url': 'https://example.com/higher',
+                'is_enabled': True,
+                'is_deleted': False,
+            },
+        )
+        current_flow = write_to_db(
+            'flow',
+            {
+                'name': 'Current repeatable flow',
+                'campaign_id': campaign['id'],
+                'rule': None,
+                'order_value': 10,
+                'action_type': 'redirect',
+                'redirect_url': 'https://example.com/current',
+                'is_enabled': True,
+                'is_deleted': False,
+                'show_once_per_visitor': False,
+            },
+        )
+        cookie_row = write_to_db(
+            'domain_cookie',
+            {'domain_id': domain['id'], 'name': 'flow_id', 'opaque_name': 'sticky_flow'},
+        )
+        client.set_cookie(cookie_row['opaque_name'], str(current_flow['id']))
+
+        response = client.get(f'/process/{campaign["id"]}', query_string={'clickId': str(uuid4())})
+
+        assert response.status_code == 302, response.text
+        assert response.headers['Location'] == current_flow['redirect_url']
+
+    def test_track_redirect__skips_show_once_current_flow_after_visit(
+        self, client, campaign, domain, write_to_db, ip2location_mock
+    ):
+        write_to_db(
+            'flow',
+            {
+                'name': 'Already passed show-once flow',
+                'campaign_id': campaign['id'],
+                'rule': None,
+                'order_value': 30,
+                'action_type': 'redirect',
+                'redirect_url': 'https://example.com/previous',
+                'is_enabled': True,
+                'is_deleted': False,
+                'show_once_per_visitor': True,
+            },
+        )
+        current_flow = write_to_db(
+            'flow',
+            {
+                'name': 'Current show-once flow',
+                'campaign_id': campaign['id'],
+                'rule': None,
+                'order_value': 20,
+                'action_type': 'redirect',
+                'redirect_url': 'https://example.com/current',
+                'is_enabled': True,
+                'is_deleted': False,
+                'show_once_per_visitor': True,
+            },
+        )
+        next_flow = write_to_db(
+            'flow',
+            {
+                'name': 'Next repeatable flow',
+                'campaign_id': campaign['id'],
+                'rule': None,
+                'order_value': 10,
+                'action_type': 'redirect',
+                'redirect_url': 'https://example.com/next',
+                'is_enabled': True,
+                'is_deleted': False,
+                'show_once_per_visitor': False,
+            },
+        )
+        cookie_row = write_to_db(
+            'domain_cookie',
+            {'domain_id': domain['id'], 'name': 'flow_id', 'opaque_name': 'sticky_flow'},
+        )
+        client.set_cookie(cookie_row['opaque_name'], str(current_flow['id']))
+
+        response = client.get(f'/process/{campaign["id"]}', query_string={'clickId': str(uuid4())})
+
+        assert response.status_code == 302, response.text
+        assert response.headers['Location'] == next_flow['redirect_url']
+
+    def test_track_redirect__skips_current_flow_when_rule_no_longer_matches(
+        self, client, campaign, domain, write_to_db, ip2location_mock
+    ):
+        current_flow = write_to_db(
+            'flow',
+            {
+                'name': 'Current non-matching flow',
+                'campaign_id': campaign['id'],
+                'rule': 'country == "US"',
+                'order_value': 20,
+                'action_type': 'redirect',
+                'redirect_url': 'https://example.com/current',
+                'is_enabled': True,
+                'is_deleted': False,
+                'show_once_per_visitor': False,
+            },
+        )
+        next_flow = write_to_db(
+            'flow',
+            {
+                'name': 'Next matching flow',
+                'campaign_id': campaign['id'],
+                'rule': None,
+                'order_value': 10,
+                'action_type': 'redirect',
+                'redirect_url': 'https://example.com/next',
+                'is_enabled': True,
+                'is_deleted': False,
+            },
+        )
+        cookie_row = write_to_db(
+            'domain_cookie',
+            {'domain_id': domain['id'], 'name': 'flow_id', 'opaque_name': 'sticky_flow'},
+        )
+        client.set_cookie(cookie_row['opaque_name'], str(current_flow['id']))
+
+        response = client.get(f'/process/{campaign["id"]}', query_string={'clickId': str(uuid4())})
+
+        assert response.status_code == 302, response.text
+        assert response.headers['Location'] == next_flow['redirect_url']
+
+    def test_track_redirect__invalid_cookie_resets_to_first_visit_selection(
+        self, client, campaign, domain, write_to_db, ip2location_mock
+    ):
+        first_flow = write_to_db(
+            'flow',
+            {
+                'name': 'First flow',
+                'campaign_id': campaign['id'],
+                'rule': None,
+                'order_value': 20,
+                'action_type': 'redirect',
+                'redirect_url': 'https://example.com/first',
+                'is_enabled': True,
+                'is_deleted': False,
+            },
+        )
+        write_to_db(
+            'flow',
+            {
+                'name': 'Second flow',
+                'campaign_id': campaign['id'],
+                'rule': None,
+                'order_value': 10,
+                'action_type': 'redirect',
+                'redirect_url': 'https://example.com/second',
+                'is_enabled': True,
+                'is_deleted': False,
+            },
+        )
+        cookie_row = write_to_db(
+            'domain_cookie',
+            {'domain_id': domain['id'], 'name': 'flow_id', 'opaque_name': 'sticky_flow'},
+        )
+        client.set_cookie(cookie_row['opaque_name'], '100500')
+
+        response = client.get(f'/process/{campaign["id"]}', query_string={'clickId': str(uuid4())})
+
+        assert response.status_code == 302, response.text
+        assert response.headers['Location'] == first_flow['redirect_url']
+
+    def test_track_redirect__returns_no_match_when_remaining_progression_flows_are_blocked(
+        self, client, campaign, domain, write_to_db, read_from_db, ip2location_mock
+    ):
+        current_flow = write_to_db(
+            'flow',
+            {
+                'name': 'Current show-once flow',
+                'campaign_id': campaign['id'],
+                'rule': None,
+                'order_value': 20,
+                'action_type': 'redirect',
+                'redirect_url': 'https://example.com/current',
+                'is_enabled': True,
+                'is_deleted': False,
+                'show_once_per_visitor': True,
+            },
+        )
+        write_to_db(
+            'flow',
+            {
+                'name': 'Remaining non-matching flow',
+                'campaign_id': campaign['id'],
+                'rule': 'country == "US"',  # ip2location_mock resolves the request IP to MD
+                'order_value': 10,
+                'action_type': 'redirect',
+                'redirect_url': 'https://example.com/remaining',
+                'is_enabled': True,
+                'is_deleted': False,
+            },
+        )
+        cookie_row = write_to_db(
+            'domain_cookie',
+            {'domain_id': domain['id'], 'name': 'flow_id', 'opaque_name': 'sticky_flow'},
+        )
+        click_id = uuid4()
+        client.set_cookie(cookie_row['opaque_name'], str(current_flow['id']))
+
+        response = client.get(f'/process/{campaign["id"]}', query_string={'clickId': str(click_id)})
+
+        assert response.status_code == 200, response.text
+        assert response.text == ''
+        assert read_from_db('track_discard')['click_id'] == click_id
+
     def test_track_redirect__tracks_discard_when_no_flow_matches(
         self, client, campaign, domain, write_to_db, read_from_db, ip2location_mock
     ):

--- a/apps/web/src/models/core_flow.js
+++ b/apps/web/src/models/core_flow.js
@@ -19,6 +19,7 @@ class CoreFlowModel {
       landingPath: null,
       orderValue: null,
       isEnabled: true,
+      showOncePerVisitor: false,
     };
   }
 
@@ -29,7 +30,8 @@ class CoreFlowModel {
     this.form.redirectUrl = payload.redirectUrl || "";
     this.form.landingArchive = null;
     this.form.landingPath = payload.landingPath || "";
-    this.form.isEnabled = payload.isEnabled || true;
+    this.form.isEnabled = payload.isEnabled ?? true;
+    this.form.showOncePerVisitor = payload.showOncePerVisitor || false;
   }
 
   resetForm() {
@@ -101,6 +103,7 @@ class CoreFlowModel {
           ? this.form.redirectUrl.trim() || null
           : null,
       isEnabled: this.form.isEnabled,
+      showOncePerVisitor: this.form.showOncePerVisitor,
     };
   }
 

--- a/apps/web/src/views/core_flow.js
+++ b/apps/web/src/views/core_flow.js
@@ -172,6 +172,26 @@ class CoreFlowView {
                           "Enabled",
                         ),
                       ]),
+                      m(".form-check.mt-3", [
+                        m("input.form-check-input", {
+                          type: "checkbox",
+                          id: "showOncePerVisitor",
+                          checked: this.model.form.showOncePerVisitor,
+                          onchange: function (event) {
+                            this.model.form.showOncePerVisitor =
+                              event.target.checked;
+                          }.bind(this),
+                        }),
+                        m(
+                          "label.form-check-label",
+                          { for: "showOncePerVisitor" },
+                          "Show only once per visitor",
+                        ),
+                        m(
+                          ".form-text",
+                          "After this visitor sees the flow, Bangi skips it when selecting their next landing.",
+                        ),
+                      ]),
                       m(
                         "button.btn.btn-primary.mt-3",
                         { type: "submit" },

--- a/infra/installer/install.sh
+++ b/infra/installer/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-BANGI_RELEASE_TAG="0.0.1a37"
+BANGI_RELEASE_TAG="0.0.1a38"
 BANGI_GITHUB_OWNER="devalentino"
 BANGI_GITHUB_REPO="bangi"
 BANGI_RAW_BASE_URL="https://raw.githubusercontent.com/${BANGI_GITHUB_OWNER}/${BANGI_GITHUB_REPO}/${BANGI_RELEASE_TAG}"

--- a/infra/installer/templates/compose.prod.yml
+++ b/infra/installer/templates/compose.prod.yml
@@ -1,6 +1,6 @@
 services:
   web:
-    image: ghcr.io/devalentino/bangi-web:0.0.1a37
+    image: ghcr.io/devalentino/bangi-web:0.0.1a38
     restart: always
     env_file:
       - /opt/bangi/shared/env/.env
@@ -10,7 +10,7 @@ services:
       - bangi
 
   api:
-    image: ghcr.io/devalentino/bangi-api:0.0.1a37
+    image: ghcr.io/devalentino/bangi-api:0.0.1a38
     restart: always
     env_file:
       - /opt/bangi/shared/env/.env


### PR DESCRIPTION
## Summary
- Add persisted `show_once_per_visitor` flow setting and expose it as required `showOncePerVisitor` on flow API create/update/detail/list surfaces.
- Update `/process` selection to treat the sticky flow cookie as `current_flow_id`, evaluate it first, and progress past show-once or non-matching current flows.
- Add dashboard form support for the `Show only once per visitor` setting and integration coverage for API serialization plus repeat-visitor progression.

## Scope
- Included: backend migration/model/schema/route/service updates, tracker cookie-boundary normalization, dashboard flow form changes, and backend integration tests.
- Not included: default-flow fallback, IP2Location availability alerts, campaign default flow UI, installer/firewall work, or local test execution.

## Risks
- Moderate: `/process` routing changes affect repeat visitors with existing flow cookies; integration tests cover repeatable current flow, show-once skip, rule mismatch, invalid cookie reset, and no-match preservation.

## Links
- Jira: https://bangitech.atlassian.net/browse/KAN-56
- Spec: https://bangitech.atlassian.net/wiki/spaces/SD/pages/12582916
