### PR TITLE
KAN-57: fix: allow campaign save without status mapping

### DIFF
--- a/apps/api/src/core/schemas.py
+++ b/apps/api/src/core/schemas.py
@@ -69,7 +69,7 @@ class CampaignCreateRequestSchema(Schema):
     costModel = fields.Enum(CostModel, required=True)
     costValue = fields.Decimal(places=2, rounding=decimal.ROUND_DOWN, required=True)
     currency = fields.Enum(Currency, required=True)
-    statusMapper = fields.Dict(required=True)
+    statusMapper = fields.Dict(required=True, allow_none=True)
 
     @validates_schema
     def validate_status_mapper(self, data, **kwargs):
@@ -81,7 +81,7 @@ class CampaignUpdateRequestSchema(Schema):
     costModel = fields.Enum(CostModel)
     costValue = fields.Decimal(places=2, rounding=decimal.ROUND_DOWN)
     currency = fields.Enum(Currency)
-    statusMapper = fields.Dict(allow_none=True, load_default=None)
+    statusMapper = fields.Dict(required=True, allow_none=True)
 
     @validates_schema
     def validate_status_mapper(self, data, **kwargs):

--- a/apps/api/src/core/services.py
+++ b/apps/api/src/core/services.py
@@ -115,8 +115,7 @@ class CampaignService:
         if currency:
             campaign.currency = currency
 
-        if status_mapper is not None:
-            campaign.status_mapper = status_mapper
+        campaign.status_mapper = status_mapper
 
         campaign.save()
 

--- a/apps/api/src/facebook_pacs/schemas.py
+++ b/apps/api/src/facebook_pacs/schemas.py
@@ -88,7 +88,7 @@ class FacebookPacsCampaignRequestSchema(Schema):
     costModel = fields.Enum(CostModel, required=True)
     costValue = fields.Decimal(places=2, rounding=decimal.ROUND_DOWN, required=True)
     currency = fields.Enum(Currency, required=True)
-    statusMapper = fields.Dict(required=True)
+    statusMapper = fields.Dict(required=True, allow_none=True)
     executorId = fields.Integer(required=True)
     adCabinetId = fields.Integer(required=True)
     businessPageId = fields.Integer(required=True)

--- a/apps/api/tests/integration/core/test_campaigns.py
+++ b/apps/api/tests/integration/core/test_campaigns.py
@@ -18,7 +18,11 @@ def test_create_campaign(client, authorization, campaign_payload, read_from_db):
         'statusMapper': campaign_payload['status_mapper'],
     }
 
-    response = client.post('/api/v2/core/campaigns', headers={'Authorization': authorization}, json=request_payload)
+    response = client.post(
+        '/api/v2/core/campaigns',
+        headers={'Authorization': authorization},
+        json=request_payload,
+    )
 
     assert response.status_code == 201, response.text
 
@@ -35,6 +39,44 @@ def test_create_campaign(client, authorization, campaign_payload, read_from_db):
     }
 
     assert json.loads(campaign['status_mapper']) == request_payload['statusMapper']
+
+
+def test_create_campaign__without_status_mapper(client, authorization, campaign_payload, read_from_db):
+    request_payload = {
+        'name': campaign_payload['name'],
+        'costModel': campaign_payload['cost_model'],
+        'costValue': campaign_payload['cost_value'],
+        'currency': campaign_payload['currency'],
+    }
+
+    response = client.post(
+        '/api/v2/core/campaigns',
+        headers={'Authorization': authorization},
+        json=request_payload,
+    )
+
+    assert response.status_code == 422, response.text
+    assert response.json == {
+        'code': 422,
+        'errors': {'json': {'statusMapper': ['Missing data for required field.']}},
+        'status': 'Unprocessable Entity',
+    }
+
+
+def test_create_campaign__accepts_null_status_mapper(client, authorization, campaign_payload, read_from_db):
+    request_payload = {
+        'name': campaign_payload['name'],
+        'costModel': campaign_payload['cost_model'],
+        'costValue': campaign_payload['cost_value'],
+        'currency': campaign_payload['currency'],
+        'statusMapper': None,
+    }
+
+    response = client.post('/api/v2/core/campaigns', headers={'Authorization': authorization}, json=request_payload)
+
+    assert response.status_code == 201, response.text
+    campaign = read_from_db('campaign')
+    assert campaign['status_mapper'] is None
 
 
 def test_campaigns_list(client, authorization, environment, campaign_payload, write_to_db):
@@ -112,13 +154,59 @@ def test_update_campaign(client, authorization, campaign, read_from_db, request_
     response = client.patch(
         f'/api/v2/core/campaigns/{campaign["id"]}',
         headers={'Authorization': authorization},
-        json={request_key: request_value},
+        json={request_key: request_value, 'statusMapper': json.loads(campaign['status_mapper'])},
     )
 
     assert response.status_code == 200, response.text
 
     campaign = read_from_db('campaign')
     assert campaign[db_key] == request_value
+
+
+def test_update_campaign__requires_status_mapper(client, authorization, campaign):
+    response = client.patch(
+        f'/api/v2/core/campaigns/{campaign["id"]}',
+        headers={'Authorization': authorization},
+        json={'name': 'Campaign updated'},
+    )
+
+    assert response.status_code == 422, response.text
+    assert response.json == {
+        'code': 422,
+        'errors': {'json': {'statusMapper': ['Missing data for required field.']}},
+        'status': 'Unprocessable Entity',
+    }
+
+
+def test_update_campaign__accepts_null_status_mapper(client, authorization, campaign, read_from_db):
+    response = client.patch(
+        f'/api/v2/core/campaigns/{campaign["id"]}',
+        headers={'Authorization': authorization},
+        json={'statusMapper': None},
+    )
+
+    assert response.status_code == 200, response.text
+    updated_campaign = read_from_db('campaign')
+    assert updated_campaign['status_mapper'] is None
+
+
+def test_update_campaign__validates_non_empty_status_mapper(client, authorization, campaign):
+    response = client.patch(
+        f'/api/v2/core/campaigns/{campaign["id"]}',
+        headers={'Authorization': authorization},
+        json={'statusMapper': {'parameter': 'state', 'mapping': {'maybe': 'unknown'}}},
+    )
+
+    assert response.status_code == 422, response.text
+    assert response.json == {
+        'code': 422,
+        'errors': {
+            'json': {
+                'statusMapper': ['statusMapper.mapping values must be one of: accept, expect, reject, trash.'],
+            },
+        },
+        'status': 'Unprocessable Entity',
+    }
 
 
 def test_campaigns_list__returns_click_summary(

--- a/apps/api/tests/integration/core/test_campaigns.py
+++ b/apps/api/tests/integration/core/test_campaigns.py
@@ -76,7 +76,7 @@ def test_create_campaign__accepts_null_status_mapper(client, authorization, camp
 
     assert response.status_code == 201, response.text
     campaign = read_from_db('campaign')
-    assert campaign['status_mapper'] is None
+    assert json.loads(campaign['status_mapper']) is None
 
 
 def test_campaigns_list(client, authorization, environment, campaign_payload, write_to_db):
@@ -187,7 +187,7 @@ def test_update_campaign__accepts_null_status_mapper(client, authorization, camp
 
     assert response.status_code == 200, response.text
     updated_campaign = read_from_db('campaign')
-    assert updated_campaign['status_mapper'] is None
+    assert json.loads(updated_campaign['status_mapper']) is None
 
 
 def test_update_campaign__validates_non_empty_status_mapper(client, authorization, campaign):

--- a/apps/api/tests/integration/facebook_pacs/test_campaigns.py
+++ b/apps/api/tests/integration/facebook_pacs/test_campaigns.py
@@ -66,6 +66,35 @@ def test_create_campaign(client, authorization, ad_cabinet, executor, business_p
     }
 
 
+def test_create_campaign__requires_status_mapper(
+    client,
+    authorization,
+    ad_cabinet,
+    executor,
+    business_page,
+):
+    request_payload = {
+        'name': 'pacs Campaign',
+        'costModel': 'cpm',
+        'costValue': 12,
+        'currency': 'eur',
+        'executorId': executor['id'],
+        'adCabinetId': ad_cabinet['id'],
+        'businessPageId': business_page['id'],
+    }
+
+    response = client.post(
+        '/api/v2/facebook/pacs/campaigns', headers={'Authorization': authorization}, json=request_payload
+    )
+
+    assert response.status_code == 422, response.text
+    assert response.json == {
+        'code': 422,
+        'errors': {'json': {'statusMapper': ['Missing data for required field.']}},
+        'status': 'Unprocessable Entity',
+    }
+
+
 def test_get_campaign(client, authorization, campaign, campaign_fa):
     response = client.get(
         f'/api/v2/facebook/pacs/campaigns/{campaign_fa["id"]}',
@@ -131,3 +160,34 @@ def test_update_campaign(client, authorization, campaign_fa, ad_cabinet, executo
 
     pacs_campaign = read_from_db('facebook_pacs_ad_campaign', filters={'id': campaign_fa['id']})
     assert pacs_campaign['business_page_id'] == new_business_page['id']
+
+
+def test_update_campaign__accepts_null_status_mapper(
+    client,
+    authorization,
+    campaign_fa,
+    ad_cabinet,
+    executor,
+    business_page,
+    read_from_db,
+):
+    request_payload = {
+        'name': 'Campaign Updated',
+        'costModel': 'cpa',
+        'costValue': 7,
+        'currency': 'usd',
+        'statusMapper': None,
+        'executorId': executor['id'],
+        'adCabinetId': ad_cabinet['id'],
+        'businessPageId': business_page['id'],
+    }
+
+    response = client.patch(
+        f'/api/v2/facebook/pacs/campaigns/{campaign_fa["id"]}',
+        headers={'Authorization': authorization},
+        json=request_payload,
+    )
+
+    assert response.status_code == 200, response.text
+    core_campaign = read_from_db('campaign', filters={'id': campaign_fa['core_campaign_id']})
+    assert core_campaign['status_mapper'] is None

--- a/apps/api/tests/integration/facebook_pacs/test_campaigns.py
+++ b/apps/api/tests/integration/facebook_pacs/test_campaigns.py
@@ -190,4 +190,4 @@ def test_update_campaign__accepts_null_status_mapper(
 
     assert response.status_code == 200, response.text
     core_campaign = read_from_db('campaign', filters={'id': campaign_fa['core_campaign_id']})
-    assert core_campaign['status_mapper'] is None
+    assert json.loads(core_campaign['status_mapper']) is None

--- a/apps/web/src/models/facebook_pacs_campaign.js
+++ b/apps/web/src/models/facebook_pacs_campaign.js
@@ -84,18 +84,16 @@ class FacebookPacsCampaignModel {
       return "Cost value must be a number.";
     }
 
-    if (!this.form.statusMapperText.trim()) {
-      return "Status mapper is required.";
-    }
+    if (this.form.statusMapperText.trim().length > 0) {
+      try {
+        let parsed = JSON.parse(this.form.statusMapperText);
 
-    try {
-      let parsed = JSON.parse(this.form.statusMapperText);
-
-      if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
-        return "Status mapper must be a JSON object.";
+        if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+          return "Status mapper must be a JSON object.";
+        }
+      } catch (error) {
+        return "Status mapper must be valid JSON.";
       }
-    } catch (error) {
-      return "Status mapper must be valid JSON.";
     }
 
     if (!this.form.executorId) {
@@ -114,7 +112,12 @@ class FacebookPacsCampaignModel {
   }
 
   buildPayload() {
-    let statusMapper = JSON.parse(this.form.statusMapperText);
+    let statusMapper = null;
+    let statusMapperText = this.form.statusMapperText.trim();
+
+    if (statusMapperText.length > 0) {
+      statusMapper = JSON.parse(statusMapperText);
+    }
 
     return {
       name: this.form.name.trim(),

--- a/apps/web/src/views/core_campaign.js
+++ b/apps/web/src/views/core_campaign.js
@@ -161,7 +161,14 @@ class CoreCampaignView {
                           id: "statusMapper",
                           rows: "4",
                           placeholder:
-                            '{"parameter":"state","mapping":{"approved":"APPROVED","rejected":"REJECTED"}}',
+                            '{\n'
+                            + '  "parameter": "state_on_the_cpa_side",\n'
+                            + '  "mapping": {\n'
+                            + '    "accept_on_the_cpa_side": "accept",\n'
+                            + '    "reject_on_the_cpa_side": "reject",\n'
+                            + '    "expect_on_the_cpa_ide": "expect"\n'
+                            + '  }\n'
+                            + '}',
                           class: "font-monospace",
                           value: this.campaignModel.form.statusMapperText,
                           oninput: function (event) {

--- a/apps/web/src/views/facebook_pacs_campaign.js
+++ b/apps/web/src/views/facebook_pacs_campaign.js
@@ -183,7 +183,14 @@ class FacebookPacsCampaignView {
                           id: "campaignStatusMapper",
                           rows: "4",
                           placeholder:
-                            '{"parameter":"state","mapping":{"approved":"APPROVED","rejected":"REJECTED"}}',
+                            '{\n'
+                            + '  "parameter": "state_on_the_cpa_side",\n'
+                            + '  "mapping": {\n'
+                            + '    "accept_on_the_cpa_side": "accept",\n'
+                            + '    "reject_on_the_cpa_side": "reject",\n'
+                            + '    "expect_on_the_cpa_ide": "expect"\n'
+                            + '  }\n'
+                            + '}',
                           value: this.model.form.statusMapperText,
                           oninput: function (event) {
                             this.model.form.statusMapperText =

--- a/infra/installer/install.sh
+++ b/infra/installer/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-BANGI_RELEASE_TAG="0.0.1a38"
+BANGI_RELEASE_TAG="0.0.1a39"
 BANGI_GITHUB_OWNER="devalentino"
 BANGI_GITHUB_REPO="bangi"
 BANGI_RAW_BASE_URL="https://raw.githubusercontent.com/${BANGI_GITHUB_OWNER}/${BANGI_GITHUB_REPO}/${BANGI_RELEASE_TAG}"

--- a/infra/installer/templates/compose.prod.yml
+++ b/infra/installer/templates/compose.prod.yml
@@ -1,6 +1,6 @@
 services:
   web:
-    image: ghcr.io/devalentino/bangi-web:0.0.1a38
+    image: ghcr.io/devalentino/bangi-web:0.0.1a39
     restart: always
     env_file:
       - /opt/bangi/shared/env/.env
@@ -10,7 +10,7 @@ services:
       - bangi
 
   api:
-    image: ghcr.io/devalentino/bangi-api:0.0.1a38
+    image: ghcr.io/devalentino/bangi-api:0.0.1a39
     restart: always
     env_file:
       - /opt/bangi/shared/env/.env


### PR DESCRIPTION
## Summary
- Makes campaign `statusMapper` required in create/update payloads while allowing `null` to explicitly disable status mapping.
- Updates core campaign persistence so `null` clears the stored status mapper.
- Updates the campaign forms to save an empty status mapper as `null`, avoid JSON parse errors, and show postback-focused helper copy.
- Adds integration coverage for missing, null, and invalid non-empty status mapper payloads.

## Scope
- Included: Core campaign API schema/service behavior, Facebook PACS campaign API schema coverage, campaign form status mapper handling, formatted status mapper placeholders, and integration tests.
- Not included: Database migrations, lead status mapping semantics, tracker postback behavior, or unrelated campaign UI changes.

## Risks
- Low. The request contract is stricter for omitted `statusMapper`; callers must send either a valid mapping object or `null`.

## Links
- Jira: https://bangitech.atlassian.net/browse/KAN-57
- Spec: https://bangitech.atlassian.net/wiki/spaces/SD/pages/12943361, https://bangitech.atlassian.net/wiki/spaces/SD/pages/12582916
