### PR TITLE
KAN-9: feat: add campaign default flow fallback

### DIFF
--- a/apps/api/migrations/013_campaign_default_flow.py
+++ b/apps/api/migrations/013_campaign_default_flow.py
@@ -1,0 +1,22 @@
+"""Peewee migrations -- 013_campaign_default_flow.py."""
+
+from contextlib import suppress
+
+import peewee as pw
+from peewee_migrate import Migrator
+
+
+with suppress(ImportError):
+    import playhouse.postgres_ext as pw_pext
+
+
+def migrate(migrator: Migrator, database: pw.Database, *, fake=False):
+    """Write your migrations here."""
+
+    migrator.sql('ALTER TABLE campaign ADD COLUMN default_flow_id INT NULL')
+
+
+def rollback(migrator: Migrator, database: pw.Database, *, fake=False):
+    """Write your rollback migrations here."""
+
+    migrator.remove_fields('campaign', 'default_flow_id')

--- a/apps/api/src/alerts/enums.py
+++ b/apps/api/src/alerts/enums.py
@@ -4,6 +4,7 @@ from enum import StrEnum
 class AlertCode(StrEnum):
     UNKNOWN = 'unknown'
     CORE_CAMPAIGN_DISCARD = 'core_campaign_discard'
+    CORE_CAMPAIGN_DEFAULT_FLOW_CONFIGURATION = 'core_campaign_default_flow_configuration'
     FACEBOOK_PACS_BUSINESS_PORTFOLIO_ACCESS_URL_MISSING = 'facebook_pacs_business_portfolio_access_url_missing'
     FACEBOOK_PACS_BUSINESS_PORTFOLIO_ACCESS_URL_EXPIRED = 'facebook_pacs_business_portfolio_access_url_expired'
     FACEBOOK_PACS_BUSINESS_PORTFOLIO_ACCESS_URL_EXPIRING_SOON = (

--- a/apps/api/src/api.py
+++ b/apps/api/src/api.py
@@ -21,6 +21,7 @@ from src.tracker.routes import process_blueprint
 configure_logging()
 
 # Alerts and workers initialization
+from src.core import alerts as core_alerts  # noqa: E402, F401
 from src.domains import alerts as domain_alerts  # noqa: E402, F401
 from src.domains import workers as domain_workers  # noqa: E402, F401
 from src.health import alerts as health_alerts  # noqa: E402, F401

--- a/apps/api/src/core/alerts.py
+++ b/apps/api/src/core/alerts.py
@@ -1,0 +1,81 @@
+from peewee import JOIN
+
+from src.alerts import Alert, AlertCode, AlertSeverity, register_alert_callback
+from src.core.entities import Campaign, Flow
+
+
+@register_alert_callback
+def collect_default_flow_alerts(container) -> list[Alert]:
+    missing_campaigns = []
+    invalid_campaigns = []
+    default_flow = Flow.alias()
+
+    campaign_rows = (
+        Campaign.select(
+            Campaign.id.alias('campaign_id'),
+            Campaign.name.alias('campaign_name'),
+            Campaign.default_flow_id,
+            default_flow.id.alias('default_flow_row_id'),
+            default_flow.is_enabled.alias('default_flow_is_enabled'),
+            default_flow.is_deleted.alias('default_flow_is_deleted'),
+        )
+        .join(
+            default_flow,
+            JOIN.LEFT_OUTER,
+            on=((default_flow.id == Campaign.default_flow_id) & (default_flow.campaign_id == Campaign.id)),
+        )
+        .where(
+            (Campaign.default_flow_id.is_null(True))
+            | (default_flow.id.is_null(True))
+            | (default_flow.is_deleted == True)
+            | (default_flow.is_enabled == False)
+        )
+        .order_by(Campaign.id.asc())
+        .dicts()
+    )
+
+    for campaign in campaign_rows:
+        if campaign['default_flow_id'] is None:
+            missing_campaigns.append({'campaignId': campaign['campaign_id'], 'campaignName': campaign['campaign_name']})
+            continue
+
+        if campaign['default_flow_row_id'] is None:
+            reason = 'missing'
+        elif campaign['default_flow_is_deleted']:
+            reason = 'deleted'
+        elif not campaign['default_flow_is_enabled']:
+            reason = 'disabled'
+        else:
+            continue
+
+        invalid_campaigns.append(
+            {
+                'campaignId': campaign['campaign_id'],
+                'campaignName': campaign['campaign_name'],
+                'defaultFlowId': campaign['default_flow_id'],
+                'reason': reason,
+            }
+        )
+
+    if not missing_campaigns and not invalid_campaigns:
+        return []
+
+    message_parts = []
+    if missing_campaigns:
+        campaign_names = ', '.join(campaign['campaignName'] for campaign in missing_campaigns)
+        message_parts.append(f'Missing default flow: {campaign_names}.')
+    if invalid_campaigns:
+        campaign_names = ', '.join(campaign['campaignName'] for campaign in invalid_campaigns)
+        message_parts.append(f'Invalid default flow: {campaign_names}.')
+
+    return [
+        Alert(
+            code=AlertCode.CORE_CAMPAIGN_DEFAULT_FLOW_CONFIGURATION,
+            message=' '.join(message_parts),
+            severity=AlertSeverity.WARNING,
+            payload={
+                'missingDefaultFlowCampaigns': missing_campaigns,
+                'invalidDefaultFlowCampaigns': invalid_campaigns,
+            },
+        )
+    ]

--- a/apps/api/src/core/entities.py
+++ b/apps/api/src/core/entities.py
@@ -47,6 +47,7 @@ class Campaign(Entity):
     currency = CharField(null=True, default=Currency.usd.value)
     status_mapper = JSONField(null=True)
     expenses_distribution_parameter = CharField(null=True)
+    default_flow_id = IntegerField(null=True)
 
 
 class Flow(Entity):

--- a/apps/api/src/core/exceptions.py
+++ b/apps/api/src/core/exceptions.py
@@ -15,3 +15,8 @@ class DoesNotExistError(ApplicationError):
 
 class CampaignDoesNotExistError(DoesNotExistError):
     message = 'Campaign does not exist'
+
+
+class InvalidCampaignDefaultFlowError(ApplicationError):
+    http_status_code = 422
+    message = 'defaultFlowId must reference a flow in this campaign.'

--- a/apps/api/src/core/routes.py
+++ b/apps/api/src/core/routes.py
@@ -7,6 +7,7 @@ from src.auth import auth
 from src.container import container
 from src.core.blueprint import Blueprint
 from src.core.enums import FlowActionType
+from src.core.exceptions import InvalidCampaignDefaultFlowError
 from src.core.schemas import (
     CampaignCreateRequestSchema,
     CampaignListResponseSchema,
@@ -114,12 +115,12 @@ class Campaign(MethodView):
                 campaign_payload.get('statusMapper'),
                 campaign_payload.get('defaultFlowId'),
             )
-        except ValueError as e:
+        except InvalidCampaignDefaultFlowError as e:
             return {
-                'code': 422,
-                'errors': {'json': {'defaultFlowId': [str(e)]}},
+                'code': e.http_status_code,
+                'errors': {'json': {'defaultFlowId': [e.message]}},
                 'status': 'Unprocessable Entity',
-            }, 422
+            }, e.http_status_code
 
 
 @blueprint.route('/filters/campaigns')

--- a/apps/api/src/core/routes.py
+++ b/apps/api/src/core/routes.py
@@ -104,14 +104,22 @@ class Campaign(MethodView):
     @auth.login_required
     def patch(self, campaign_payload, campaignId):
         campaign_service = container.get(CampaignService)
-        campaign_service.update(
-            campaignId,
-            campaign_payload.get('name'),
-            campaign_payload.get('costModel'),
-            campaign_payload.get('costValue'),
-            campaign_payload.get('currency'),
-            campaign_payload.get('statusMapper'),
-        )
+        try:
+            campaign_service.update(
+                campaignId,
+                campaign_payload.get('name'),
+                campaign_payload.get('costModel'),
+                campaign_payload.get('costValue'),
+                campaign_payload.get('currency'),
+                campaign_payload.get('statusMapper'),
+                campaign_payload.get('defaultFlowId'),
+            )
+        except ValueError as e:
+            return {
+                'code': 422,
+                'errors': {'json': {'defaultFlowId': [str(e)]}},
+                'status': 'Unprocessable Entity',
+            }, 422
 
 
 @blueprint.route('/filters/campaigns')

--- a/apps/api/src/core/schemas.py
+++ b/apps/api/src/core/schemas.py
@@ -82,6 +82,7 @@ class CampaignUpdateRequestSchema(Schema):
     costValue = fields.Decimal(places=2, rounding=decimal.ROUND_DOWN)
     currency = fields.Enum(Currency)
     statusMapper = fields.Dict(required=True, allow_none=True)
+    defaultFlowId = fields.Integer(required=True, allow_none=True)
 
     @validates_schema
     def validate_status_mapper(self, data, **kwargs):
@@ -101,6 +102,7 @@ class CampaignResponseSchema(Schema):
     costValue = fields.Decimal(places=2, rounding=decimal.ROUND_DOWN, required=True)
     currency = fields.String(required=True)
     statusMapper = fields.Dict(allow_none=True)
+    defaultFlowId = fields.Integer(allow_none=True)
     internalProcessUrl = fields.String(allow_none=True)
     expensesDistributionParameter = fields.String(allow_none=True)
     summary = fields.Nested(CampaignSummaryResponseSchema(), required=True)

--- a/apps/api/src/core/services.py
+++ b/apps/api/src/core/services.py
@@ -97,7 +97,28 @@ class CampaignService:
         campaign.save()
         return campaign
 
-    def update(self, campaign_id, name=None, cost_model=None, cost_value=None, currency=None, status_mapper=None):
+    def _validate_default_flow(self, campaign_id, default_flow_id):
+        if default_flow_id is None:
+            return
+
+        try:
+            flow = Flow.get_by_id(default_flow_id)
+        except Flow.DoesNotExist as exc:
+            raise ValueError('defaultFlowId must reference a flow in this campaign.') from exc
+
+        if flow.campaign.id != campaign_id or flow.is_deleted:
+            raise ValueError('defaultFlowId must reference a flow in this campaign.')
+
+    def update(
+        self,
+        campaign_id,
+        name=None,
+        cost_model=None,
+        cost_value=None,
+        currency=None,
+        status_mapper=None,
+        default_flow_id=None,
+    ):
         try:
             campaign = Campaign.get_by_id(campaign_id)
         except Campaign.DoesNotExist as exc:
@@ -116,6 +137,8 @@ class CampaignService:
             campaign.currency = currency
 
         campaign.status_mapper = status_mapper
+        self._validate_default_flow(campaign_id, default_flow_id)
+        campaign.default_flow_id = default_flow_id
 
         campaign.save()
 
@@ -311,6 +334,7 @@ class FlowService:
         flow = self.get(flow_id, campaign_id)
         flow.is_deleted = True
         flow.save()
+        Campaign.update(default_flow_id=None).where(Campaign.default_flow_id == flow.id).execute()
 
     def bulk_update_order(self, campaign_id, order):
         # TODO: move to repo
@@ -329,12 +353,18 @@ class FlowService:
 
     def process_flows(self, campaign_id: int, client: Client, current_flow_id=None):
         flows = list(
-            Flow.select()
+            Flow.select(Flow, Campaign)
+            .join(Campaign)
             .where((Flow.campaign_id == campaign_id) & (Flow.is_enabled == True) & (Flow.is_deleted == False))
             .order_by(Flow.order_value.desc(), Flow.id.asc())
         )
-        current_index = None
+        default_flow = None
+        for flow in flows:
+            if flow.id == flow.campaign.default_flow_id:
+                default_flow = flow
+                break
 
+        current_index = None
         if current_flow_id is not None:
             for index, flow in enumerate(flows):
                 if flow.id == current_flow_id:
@@ -365,10 +395,13 @@ class FlowService:
                     break
 
         if matched_flow is None:
-            logger.warning(
-                'Failed to process flows', extra={'campaign_id': campaign_id, 'flows': [f.to_dict() for f in flows]}
-            )
-            return None, None, None
+            matched_flow = default_flow
+
+            if matched_flow is None:
+                logger.warning(
+                    'Failed to process flows', extra={'campaign_id': campaign_id, 'flows': [f.to_dict() for f in flows]}
+                )
+                return None, None, None
 
         if matched_flow.action_type == FlowActionType.redirect:
             return matched_flow.action_type, matched_flow.redirect_url, matched_flow.id

--- a/apps/api/src/core/services.py
+++ b/apps/api/src/core/services.py
@@ -15,7 +15,12 @@ from wireup import Inject, injectable
 
 from src.core.entities import Campaign, Flow
 from src.core.enums import FlowActionType, SortOrder
-from src.core.exceptions import CampaignDoesNotExistError, DoesNotExistError, LandingPageUploadError
+from src.core.exceptions import (
+    CampaignDoesNotExistError,
+    DoesNotExistError,
+    InvalidCampaignDefaultFlowError,
+    LandingPageUploadError,
+)
 from src.core.models import Client
 from src.core.repositories import CampaignRepository
 from src.core.utils import log_execution_time
@@ -104,10 +109,10 @@ class CampaignService:
         try:
             flow = Flow.get_by_id(default_flow_id)
         except Flow.DoesNotExist as exc:
-            raise ValueError('defaultFlowId must reference a flow in this campaign.') from exc
+            raise InvalidCampaignDefaultFlowError() from exc
 
         if flow.campaign.id != campaign_id or flow.is_deleted:
-            raise ValueError('defaultFlowId must reference a flow in this campaign.')
+            raise InvalidCampaignDefaultFlowError()
 
     def update(
         self,

--- a/apps/api/tests/integration/conftest.py
+++ b/apps/api/tests/integration/conftest.py
@@ -6,6 +6,7 @@ from unittest import mock
 import pytest
 from peewee import MySQLDatabase
 from peewee_migrate import Router
+from pymysql import cursors
 from pytest_mysql import factories
 
 mysql_in_docker = factories.mysql_noproc(
@@ -97,3 +98,14 @@ def environment():
     from src.container import container
 
     return container.params._ConfigStore__bag
+
+
+@pytest.fixture
+def set_default_flow_id(mysql):
+    def _set_default_flow_id(campaign_id, flow_id):
+        with mysql.cursor(cursors.DictCursor) as cur:
+            cur.execute('UPDATE campaign SET default_flow_id = %s WHERE id = %s', (flow_id, campaign_id))
+
+        mysql.commit()
+
+    return _set_default_flow_id

--- a/apps/api/tests/integration/core/test_alerts.py
+++ b/apps/api/tests/integration/core/test_alerts.py
@@ -2,14 +2,11 @@ from pymysql import cursors
 
 
 def test_get_alerts__returns_campaign_default_flow_configuration_alert(
-    client, authorization, campaign, campaign_payload, write_to_db
+    client, authorization, campaign, campaign_payload, write_to_db, set_default_flow_id
 ):
     disabled_default_flow_campaign = write_to_db(
         'campaign',
-        campaign_payload | {
-            'name': 'Disabled default flow campaign',
-            'default_flow_id': 1,  # id of disabled_default_flow
-        },
+        campaign_payload | {'name': 'Disabled default flow campaign'},
     )
     disabled_default_flow = write_to_db(
         'flow',
@@ -25,7 +22,7 @@ def test_get_alerts__returns_campaign_default_flow_configuration_alert(
         },
     )
 
-    assert disabled_default_flow_campaign['default_flow_id'] == disabled_default_flow['id']
+    set_default_flow_id(disabled_default_flow_campaign['id'], disabled_default_flow['id'])
 
     response = client.get('/api/v2/alerts', headers={'Authorization': authorization})
 
@@ -62,15 +59,9 @@ def test_get_alerts__returns_campaign_default_flow_configuration_alert(
 
 
 def test_get_alerts__does_not_return_campaign_default_flow_alert_when_default_is_runnable(
-    client, authorization, campaign_payload, write_to_db
+    client, authorization, campaign_payload, write_to_db, set_default_flow_id
 ):
-    campaign_with_default_flow = write_to_db(
-        'campaign',
-        campaign_payload | {
-            'name': 'Configured campaign',
-            'default_flow_id': 1,  # id of disabled_default_flow
-        },
-    )
+    campaign_with_default_flow = write_to_db('campaign', campaign_payload | {'name': 'Configured campaign'})
     default_flow = write_to_db(
         'flow',
         {
@@ -85,7 +76,7 @@ def test_get_alerts__does_not_return_campaign_default_flow_alert_when_default_is
         },
     )
 
-    assert campaign_with_default_flow['default_flow_id'] == default_flow['id']
+    set_default_flow_id(campaign_with_default_flow['id'], default_flow['id'])
 
     response = client.get('/api/v2/alerts', headers={'Authorization': authorization})
 

--- a/apps/api/tests/integration/core/test_alerts.py
+++ b/apps/api/tests/integration/core/test_alerts.py
@@ -1,6 +1,3 @@
-from pymysql import cursors
-
-
 def test_get_alerts__returns_campaign_default_flow_configuration_alert(
     client, authorization, campaign, campaign_payload, write_to_db, set_default_flow_id
 ):

--- a/apps/api/tests/integration/core/test_alerts.py
+++ b/apps/api/tests/integration/core/test_alerts.py
@@ -1,0 +1,93 @@
+from pymysql import cursors
+
+
+def test_get_alerts__returns_campaign_default_flow_configuration_alert(
+    client, authorization, campaign, campaign_payload, write_to_db
+):
+    disabled_default_flow_campaign = write_to_db(
+        'campaign',
+        campaign_payload | {
+            'name': 'Disabled default flow campaign',
+            'default_flow_id': 1,  # id of disabled_default_flow
+        },
+    )
+    disabled_default_flow = write_to_db(
+        'flow',
+        {
+            'name': 'Disabled default',
+            'campaign_id': disabled_default_flow_campaign['id'],
+            'rule': None,
+            'order_value': 1,
+            'action_type': 'redirect',
+            'redirect_url': 'https://example.com/default',
+            'is_enabled': False,
+            'is_deleted': False,
+        },
+    )
+
+    assert disabled_default_flow_campaign['default_flow_id'] == disabled_default_flow['id']
+
+    response = client.get('/api/v2/alerts', headers={'Authorization': authorization})
+
+    assert response.status_code == 200, response.text
+    assert response.json == {
+        'content': [
+            {
+                'code': 'core_campaign_default_flow_configuration',
+                'message': (
+                    f'Missing default flow: {campaign["name"]}. '
+                    f'Invalid default flow: {disabled_default_flow_campaign["name"]}.'
+                ),
+                'severity': 'warning',
+                'source': 'src.core.alerts',
+                'payload': {
+                    'missingDefaultFlowCampaigns': [
+                        {
+                            'campaignId': campaign['id'],
+                            'campaignName': campaign['name'],
+                        }
+                    ],
+                    'invalidDefaultFlowCampaigns': [
+                        {
+                            'campaignId': disabled_default_flow_campaign['id'],
+                            'campaignName': disabled_default_flow_campaign['name'],
+                            'defaultFlowId': disabled_default_flow['id'],
+                            'reason': 'disabled',
+                        }
+                    ],
+                },
+            }
+        ]
+    }
+
+
+def test_get_alerts__does_not_return_campaign_default_flow_alert_when_default_is_runnable(
+    client, authorization, campaign_payload, write_to_db
+):
+    campaign_with_default_flow = write_to_db(
+        'campaign',
+        campaign_payload | {
+            'name': 'Configured campaign',
+            'default_flow_id': 1,  # id of disabled_default_flow
+        },
+    )
+    default_flow = write_to_db(
+        'flow',
+        {
+            'name': 'Configured default',
+            'campaign_id': campaign_with_default_flow['id'],
+            'rule': None,
+            'order_value': 1,
+            'action_type': 'redirect',
+            'redirect_url': 'https://example.com/default',
+            'is_enabled': True,
+            'is_deleted': False,
+        },
+    )
+
+    assert campaign_with_default_flow['default_flow_id'] == default_flow['id']
+
+    response = client.get('/api/v2/alerts', headers={'Authorization': authorization})
+
+    assert response.status_code == 200, response.text
+    assert response.json == {'content': []}

--- a/apps/api/tests/integration/core/test_campaigns.py
+++ b/apps/api/tests/integration/core/test_campaigns.py
@@ -34,6 +34,7 @@ def test_create_campaign(client, authorization, campaign_payload, read_from_db):
         'cost_value': request_payload['costValue'],
         'currency': request_payload['currency'],
         'expenses_distribution_parameter': None,
+        'default_flow_id': None,
         'status_mapper': mock.ANY,
         'created_at': mock.ANY,
     }
@@ -95,6 +96,7 @@ def test_campaigns_list(client, authorization, environment, campaign_payload, wr
                 'costValue': campaign['cost_value'],
                 'currency': campaign['currency'],
                 'expensesDistributionParameter': campaign['expenses_distribution_parameter'],
+                'defaultFlowId': campaign['default_flow_id'],
                 'id': campaign['id'],
                 'name': campaign['name'],
                 'internalProcessUrl': f'{environment["INTERNAL_PROCESS_BASE_URL"]}/{campaign["id"]}',
@@ -122,6 +124,7 @@ def test_get_campaign(client, authorization, campaign, environment):
         'costValue': campaign['cost_value'],
         'currency': campaign['currency'],
         'expensesDistributionParameter': campaign['expenses_distribution_parameter'],
+        'defaultFlowId': campaign['default_flow_id'],
         'internalProcessUrl': f'{environment["INTERNAL_PROCESS_BASE_URL"]}/{campaign["id"]}',
         'summary': {
             'clickCount': 0,
@@ -154,7 +157,7 @@ def test_update_campaign(client, authorization, campaign, read_from_db, request_
     response = client.patch(
         f'/api/v2/core/campaigns/{campaign["id"]}',
         headers={'Authorization': authorization},
-        json={request_key: request_value, 'statusMapper': json.loads(campaign['status_mapper'])},
+        json={request_key: request_value, 'statusMapper': json.loads(campaign['status_mapper']), 'defaultFlowId': None},
     )
 
     assert response.status_code == 200, response.text
@@ -173,7 +176,12 @@ def test_update_campaign__requires_status_mapper(client, authorization, campaign
     assert response.status_code == 422, response.text
     assert response.json == {
         'code': 422,
-        'errors': {'json': {'statusMapper': ['Missing data for required field.']}},
+        'errors': {
+            'json': {
+                'defaultFlowId': ['Missing data for required field.'],
+                'statusMapper': ['Missing data for required field.'],
+            }
+        },
         'status': 'Unprocessable Entity',
     }
 
@@ -182,7 +190,7 @@ def test_update_campaign__accepts_null_status_mapper(client, authorization, camp
     response = client.patch(
         f'/api/v2/core/campaigns/{campaign["id"]}',
         headers={'Authorization': authorization},
-        json={'statusMapper': None},
+        json={'statusMapper': None, 'defaultFlowId': None},
     )
 
     assert response.status_code == 200, response.text
@@ -194,7 +202,7 @@ def test_update_campaign__validates_non_empty_status_mapper(client, authorizatio
     response = client.patch(
         f'/api/v2/core/campaigns/{campaign["id"]}',
         headers={'Authorization': authorization},
-        json={'statusMapper': {'parameter': 'state', 'mapping': {'maybe': 'unknown'}}},
+        json={'statusMapper': {'parameter': 'state', 'mapping': {'maybe': 'unknown'}}, 'defaultFlowId': None},
     )
 
     assert response.status_code == 422, response.text
@@ -207,6 +215,53 @@ def test_update_campaign__validates_non_empty_status_mapper(client, authorizatio
         },
         'status': 'Unprocessable Entity',
     }
+
+
+def test_update_campaign__sets_default_flow(client, authorization, campaign, flow, read_from_db):
+    response = client.patch(
+        f'/api/v2/core/campaigns/{campaign["id"]}',
+        headers={'Authorization': authorization},
+        json={'statusMapper': json.loads(campaign['status_mapper']), 'defaultFlowId': flow['id']},
+    )
+
+    assert response.status_code == 200, response.text
+    assert read_from_db('campaign')['default_flow_id'] == flow['id']
+
+
+def test_update_campaign__rejects_default_flow_from_another_campaign(
+    client, authorization, campaign, campaign_payload, flow, write_to_db
+):
+    other_campaign = write_to_db('campaign', campaign_payload | {'name': 'Other campaign'})
+
+    response = client.patch(
+        f'/api/v2/core/campaigns/{other_campaign["id"]}',
+        headers={'Authorization': authorization},
+        json={'statusMapper': json.loads(other_campaign['status_mapper']), 'defaultFlowId': flow['id']},
+    )
+
+    assert response.status_code == 422, response.text
+    assert response.json == {
+        'code': 422,
+        'errors': {'json': {'defaultFlowId': ['defaultFlowId must reference a flow in this campaign.']}},
+        'status': 'Unprocessable Entity',
+    }
+
+
+def test_delete_flow__clears_campaign_default_flow(client, authorization, campaign, flow, read_from_db):
+    setup_response = client.patch(
+        f'/api/v2/core/campaigns/{campaign["id"]}',
+        headers={'Authorization': authorization},
+        json={'statusMapper': json.loads(campaign['status_mapper']), 'defaultFlowId': flow['id']},
+    )
+    assert setup_response.status_code == 200, setup_response.text
+
+    response = client.delete(
+        f'/api/v2/core/campaigns/{campaign["id"]}/flows/{flow["id"]}',
+        headers={'Authorization': authorization},
+    )
+
+    assert response.status_code == 204, response.text
+    assert read_from_db('campaign')['default_flow_id'] is None
 
 
 def test_campaigns_list__returns_click_summary(
@@ -264,6 +319,7 @@ def test_campaigns_list__returns_click_summary(
                 'costModel': first_campaign['cost_model'],
                 'costValue': first_campaign['cost_value'],
                 'currency': first_campaign['currency'],
+                'defaultFlowId': first_campaign['default_flow_id'],
                 'expensesDistributionParameter': first_campaign['expenses_distribution_parameter'],
                 'id': first_campaign['id'],
                 'name': first_campaign['name'],
@@ -279,6 +335,7 @@ def test_campaigns_list__returns_click_summary(
                 'costModel': second_campaign['cost_model'],
                 'costValue': second_campaign['cost_value'],
                 'currency': second_campaign['currency'],
+                'defaultFlowId': second_campaign['default_flow_id'],
                 'expensesDistributionParameter': second_campaign['expenses_distribution_parameter'],
                 'id': second_campaign['id'],
                 'name': second_campaign['name'],
@@ -294,6 +351,7 @@ def test_campaigns_list__returns_click_summary(
                 'costModel': idle_campaign['cost_model'],
                 'costValue': idle_campaign['cost_value'],
                 'currency': idle_campaign['currency'],
+                'defaultFlowId': idle_campaign['default_flow_id'],
                 'expensesDistributionParameter': idle_campaign['expenses_distribution_parameter'],
                 'id': idle_campaign['id'],
                 'name': idle_campaign['name'],
@@ -339,6 +397,7 @@ def test_get_campaign__returns_click_summary(client, authorization, campaign, en
         'costModel': campaign['cost_model'],
         'costValue': campaign['cost_value'],
         'currency': campaign['currency'],
+        'defaultFlowId': campaign['default_flow_id'],
         'expensesDistributionParameter': campaign['expenses_distribution_parameter'],
         'internalProcessUrl': f'{environment["INTERNAL_PROCESS_BASE_URL"]}/{campaign["id"]}',
         'summary': {
@@ -401,6 +460,7 @@ def test_campaigns_list__sorts_by_click_share(client, authorization, environment
                 'costModel': high_share_campaign['cost_model'],
                 'costValue': high_share_campaign['cost_value'],
                 'currency': high_share_campaign['currency'],
+                'defaultFlowId': high_share_campaign['default_flow_id'],
                 'expensesDistributionParameter': high_share_campaign['expenses_distribution_parameter'],
                 'id': high_share_campaign['id'],
                 'name': high_share_campaign['name'],
@@ -416,6 +476,7 @@ def test_campaigns_list__sorts_by_click_share(client, authorization, environment
                 'costModel': low_share_campaign['cost_model'],
                 'costValue': low_share_campaign['cost_value'],
                 'currency': low_share_campaign['currency'],
+                'defaultFlowId': low_share_campaign['default_flow_id'],
                 'expensesDistributionParameter': low_share_campaign['expenses_distribution_parameter'],
                 'id': low_share_campaign['id'],
                 'name': low_share_campaign['name'],
@@ -431,6 +492,7 @@ def test_campaigns_list__sorts_by_click_share(client, authorization, environment
                 'costModel': no_clicks_campaign['cost_model'],
                 'costValue': no_clicks_campaign['cost_value'],
                 'currency': no_clicks_campaign['currency'],
+                'defaultFlowId': no_clicks_campaign['default_flow_id'],
                 'expensesDistributionParameter': no_clicks_campaign['expenses_distribution_parameter'],
                 'id': no_clicks_campaign['id'],
                 'name': no_clicks_campaign['name'],
@@ -492,6 +554,7 @@ def test_campaigns_list__sorts_by_last_activity_at(client, authorization, enviro
                 'costModel': newest_campaign['cost_model'],
                 'costValue': newest_campaign['cost_value'],
                 'currency': newest_campaign['currency'],
+                'defaultFlowId': newest_campaign['default_flow_id'],
                 'expensesDistributionParameter': newest_campaign['expenses_distribution_parameter'],
                 'id': newest_campaign['id'],
                 'internalProcessUrl': f'{environment["INTERNAL_PROCESS_BASE_URL"]}/{newest_campaign["id"]}',
@@ -503,6 +566,7 @@ def test_campaigns_list__sorts_by_last_activity_at(client, authorization, enviro
                 'costModel': older_campaign['cost_model'],
                 'costValue': older_campaign['cost_value'],
                 'currency': older_campaign['currency'],
+                'defaultFlowId': older_campaign['default_flow_id'],
                 'expensesDistributionParameter': older_campaign['expenses_distribution_parameter'],
                 'id': older_campaign['id'],
                 'internalProcessUrl': f'{environment["INTERNAL_PROCESS_BASE_URL"]}/{older_campaign["id"]}',
@@ -514,6 +578,7 @@ def test_campaigns_list__sorts_by_last_activity_at(client, authorization, enviro
                 'costModel': no_activity_campaign['cost_model'],
                 'costValue': no_activity_campaign['cost_value'],
                 'currency': no_activity_campaign['currency'],
+                'defaultFlowId': no_activity_campaign['default_flow_id'],
                 'expensesDistributionParameter': no_activity_campaign['expenses_distribution_parameter'],
                 'id': no_activity_campaign['id'],
                 'internalProcessUrl': f'{environment["INTERNAL_PROCESS_BASE_URL"]}/{no_activity_campaign["id"]}',

--- a/apps/api/tests/integration/core/test_campaigns.py
+++ b/apps/api/tests/integration/core/test_campaigns.py
@@ -247,13 +247,11 @@ def test_update_campaign__rejects_default_flow_from_another_campaign(
     }
 
 
-def test_delete_flow__clears_campaign_default_flow(client, authorization, campaign, flow, read_from_db):
-    setup_response = client.patch(
-        f'/api/v2/core/campaigns/{campaign["id"]}',
-        headers={'Authorization': authorization},
-        json={'statusMapper': json.loads(campaign['status_mapper']), 'defaultFlowId': flow['id']},
-    )
-    assert setup_response.status_code == 200, setup_response.text
+def test_delete_flow__clears_campaign_default_flow(
+    client, authorization, campaign, flow, read_from_db, set_default_flow_id
+):
+    set_default_flow_id(campaign['id'], flow['id'])
+    assert read_from_db('campaign', filters={'id': campaign['id']})['default_flow_id'] == flow['id']
 
     response = client.delete(
         f'/api/v2/core/campaigns/{campaign["id"]}/flows/{flow["id"]}',

--- a/apps/api/tests/integration/facebook_pacs/test_campaigns.py
+++ b/apps/api/tests/integration/facebook_pacs/test_campaigns.py
@@ -51,6 +51,7 @@ def test_create_campaign(client, authorization, ad_cabinet, executor, business_p
         'currency': request_payload['currency'],
         'status_mapper': mock.ANY,
         'expenses_distribution_parameter': None,
+        'default_flow_id': None,
         'created_at': mock.ANY,
     }
     assert json.loads(core_campaign['status_mapper']) == request_payload['statusMapper']
@@ -154,6 +155,7 @@ def test_update_campaign(client, authorization, campaign_fa, ad_cabinet, executo
         'currency': request_payload['currency'],
         'status_mapper': mock.ANY,
         'expenses_distribution_parameter': mock.ANY,
+        'default_flow_id': None,
         'created_at': mock.ANY,
     }
     assert json.loads(core_campaign['status_mapper']) == request_payload['statusMapper']

--- a/apps/api/tests/integration/test_health.py
+++ b/apps/api/tests/integration/test_health.py
@@ -6,6 +6,11 @@ from unittest import mock
 import pytest
 
 
+@pytest.fixture
+def assign_default_flow_for_the_campaign(campaign, flow, set_default_flow_id):
+    set_default_flow_id(campaign['id'], flow['id'])
+
+
 def test_health(client):
     response = client.get('/api/v2/health')
     assert response.status_code == 200, response.text
@@ -557,6 +562,7 @@ class TestCertificateHealthDiagnostics:
 
 
 class TestCertificateAlerts:
+    @pytest.mark.usefixtures('assign_default_flow_for_the_campaign')
     def test_first_issuance_failure_does_not_create_alert(
         self, client, authorization, write_to_db, campaign, timestamp
     ):
@@ -595,6 +601,7 @@ class TestCertificateAlerts:
         assert response.status_code == 200, response.text
         assert response.json == {'content': []}
 
+    @pytest.mark.usefixtures('assign_default_flow_for_the_campaign')
     def test_repeated_first_issuance_failure_creates_warning_alert(
         self, client, authorization, write_to_db, campaign, timestamp
     ):

--- a/apps/api/tests/integration/track/test_alerts.py
+++ b/apps/api/tests/integration/track/test_alerts.py
@@ -1,6 +1,13 @@
+import pytest
 from fixtures.utils import click_uuid
 
 
+@pytest.fixture
+def assign_default_flow_for_the_campaign(campaign, flow, set_default_flow_id):
+    set_default_flow_id(campaign['id'], flow['id'])
+
+
+@pytest.mark.usefixtures('assign_default_flow_for_the_campaign')
 def test_get_alerts__suppresses_discard_alert_when_1h_total_is_too_low(
     client, authorization, campaign, write_to_db, timestamp
 ):
@@ -36,6 +43,7 @@ def test_get_alerts__suppresses_discard_alert_when_1h_total_is_too_low(
     assert response.json == {'content': []}
 
 
+@pytest.mark.usefixtures('assign_default_flow_for_the_campaign')
 def test_get_alerts__returns_info_discard_alert(client, authorization, campaign, write_to_db, timestamp):
     for index in range(100):
         click = write_to_db(
@@ -92,6 +100,7 @@ def test_get_alerts__returns_info_discard_alert(client, authorization, campaign,
     }
 
 
+@pytest.mark.usefixtures('assign_default_flow_for_the_campaign')
 def test_get_alerts__returns_warning_discard_alert(client, authorization, campaign, write_to_db, timestamp):
     # Inside all windows: contributes to 5m, 1h, and 1d.
     for index in range(25):

--- a/apps/api/tests/integration/track/test_process.py
+++ b/apps/api/tests/integration/track/test_process.py
@@ -249,7 +249,7 @@ class TestTrackRedirect:
         assert read_from_db('track_discard')['click_id'] == click_id
 
     def test_track_redirect__uses_default_flow_when_no_normal_flow_matches(
-        self, client, authorization, campaign, domain, write_to_db, read_from_db, ip2location_mock
+        self, client, authorization, campaign, domain, write_to_db, read_from_db, set_default_flow_id, ip2location_mock
     ):
         click_id = uuid4()
         write_to_db(
@@ -279,12 +279,8 @@ class TestTrackRedirect:
                 'show_once_per_visitor': True,
             },
         )
-        setup_response = client.patch(
-            f'/api/v2/core/campaigns/{campaign["id"]}',
-            headers={'Authorization': authorization},
-            json={'statusMapper': json.loads(campaign['status_mapper']), 'defaultFlowId': default_flow['id']},
-        )
-        assert setup_response.status_code == 200, setup_response.text
+        set_default_flow_id(campaign['id'], default_flow['id'])
+
         cookie_row = write_to_db(
             'domain_cookie',
             {'domain_id': domain['id'], 'name': 'flow_id', 'opaque_name': 'sticky_flow'},
@@ -298,7 +294,7 @@ class TestTrackRedirect:
         assert read_from_db('track_discard') is None
 
     def test_track_redirect__normal_match_takes_precedence_over_default_flow(
-        self, client, authorization, campaign, domain, write_to_db, ip2location_mock
+        self, client, authorization, campaign, domain, write_to_db, set_default_flow_id, ip2location_mock
     ):
         normal_flow = write_to_db(
             'flow',
@@ -326,12 +322,7 @@ class TestTrackRedirect:
                 'is_deleted': False,
             },
         )
-        setup_response = client.patch(
-            f'/api/v2/core/campaigns/{campaign["id"]}',
-            headers={'Authorization': authorization},
-            json={'statusMapper': json.loads(campaign['status_mapper']), 'defaultFlowId': default_flow['id']},
-        )
-        assert setup_response.status_code == 200, setup_response.text
+        set_default_flow_id(campaign['id'], default_flow['id'])
 
         response = client.get(f'/process/{campaign["id"]}', query_string={'clickId': str(uuid4())})
 
@@ -346,7 +337,16 @@ class TestTrackRedirect:
         ],
     )
     def test_track_redirect__does_not_use_unrunnable_default_flow(
-        self, client, authorization, campaign, domain, write_to_db, read_from_db, ip2location_mock, default_flow_values
+        self,
+        client,
+        authorization,
+        campaign,
+        domain,
+        write_to_db,
+        read_from_db,
+        set_default_flow_id,
+        ip2location_mock,
+        default_flow_values,
     ):
         click_id = uuid4()
         default_flow = write_to_db(
@@ -361,12 +361,7 @@ class TestTrackRedirect:
                 **default_flow_values,
             },
         )
-        setup_response = client.patch(
-            f'/api/v2/core/campaigns/{campaign["id"]}',
-            headers={'Authorization': authorization},
-            json={'statusMapper': json.loads(campaign['status_mapper']), 'defaultFlowId': default_flow['id']},
-        )
-        assert setup_response.status_code == 200, setup_response.text
+        set_default_flow_id(campaign['id'], default_flow['id'])
 
         response = client.get(f'/process/{campaign["id"]}', query_string={'clickId': str(click_id)})
 

--- a/apps/api/tests/integration/track/test_process.py
+++ b/apps/api/tests/integration/track/test_process.py
@@ -290,6 +290,8 @@ class TestTrackRedirect:
         response = client.get(f'/process/{campaign["id"]}', query_string={'clickId': str(click_id)})
 
         assert response.status_code == 302, response.text
+
+        # rules had not been evaluated for default flow, redirected despite MD IP address
         assert response.headers['Location'] == default_flow['redirect_url']
         assert read_from_db('track_discard') is None
 

--- a/apps/api/tests/integration/track/test_process.py
+++ b/apps/api/tests/integration/track/test_process.py
@@ -248,6 +248,159 @@ class TestTrackRedirect:
         assert response.text == ''
         assert read_from_db('track_discard')['click_id'] == click_id
 
+    def test_track_redirect__uses_default_flow_when_no_normal_flow_matches(
+        self, client, authorization, campaign, domain, write_to_db, read_from_db, ip2location_mock
+    ):
+        click_id = uuid4()
+        write_to_db(
+            'flow',
+            {
+                'name': 'US only',
+                'campaign_id': campaign['id'],
+                'rule': 'country == "US"',
+                'order_value': 20,
+                'action_type': 'redirect',
+                'redirect_url': 'https://example.com/us',
+                'is_enabled': True,
+                'is_deleted': False,
+            },
+        )
+        default_flow = write_to_db(
+            'flow',
+            {
+                'name': 'Campaign default',
+                'campaign_id': campaign['id'],
+                'rule': 'country == "US"',
+                'order_value': 10,
+                'action_type': 'redirect',
+                'redirect_url': 'https://example.com/default',
+                'is_enabled': True,
+                'is_deleted': False,
+                'show_once_per_visitor': True,
+            },
+        )
+        setup_response = client.patch(
+            f'/api/v2/core/campaigns/{campaign["id"]}',
+            headers={'Authorization': authorization},
+            json={'statusMapper': json.loads(campaign['status_mapper']), 'defaultFlowId': default_flow['id']},
+        )
+        assert setup_response.status_code == 200, setup_response.text
+        cookie_row = write_to_db(
+            'domain_cookie',
+            {'domain_id': domain['id'], 'name': 'flow_id', 'opaque_name': 'sticky_flow'},
+        )
+        client.set_cookie(cookie_row['opaque_name'], str(default_flow['id']))
+
+        response = client.get(f'/process/{campaign["id"]}', query_string={'clickId': str(click_id)})
+
+        assert response.status_code == 302, response.text
+        assert response.headers['Location'] == default_flow['redirect_url']
+        assert read_from_db('track_discard') is None
+
+    def test_track_redirect__normal_match_takes_precedence_over_default_flow(
+        self, client, authorization, campaign, domain, write_to_db, ip2location_mock
+    ):
+        normal_flow = write_to_db(
+            'flow',
+            {
+                'name': 'Normal match',
+                'campaign_id': campaign['id'],
+                'rule': None,
+                'order_value': 20,
+                'action_type': 'redirect',
+                'redirect_url': 'https://example.com/normal',
+                'is_enabled': True,
+                'is_deleted': False,
+            },
+        )
+        default_flow = write_to_db(
+            'flow',
+            {
+                'name': 'Campaign default',
+                'campaign_id': campaign['id'],
+                'rule': None,
+                'order_value': 10,
+                'action_type': 'redirect',
+                'redirect_url': 'https://example.com/default',
+                'is_enabled': True,
+                'is_deleted': False,
+            },
+        )
+        setup_response = client.patch(
+            f'/api/v2/core/campaigns/{campaign["id"]}',
+            headers={'Authorization': authorization},
+            json={'statusMapper': json.loads(campaign['status_mapper']), 'defaultFlowId': default_flow['id']},
+        )
+        assert setup_response.status_code == 200, setup_response.text
+
+        response = client.get(f'/process/{campaign["id"]}', query_string={'clickId': str(uuid4())})
+
+        assert response.status_code == 302, response.text
+        assert response.headers['Location'] == normal_flow['redirect_url']
+
+    @pytest.mark.parametrize(
+        'default_flow_values',
+        [
+            {'is_enabled': False, 'is_deleted': False},
+            {'is_enabled': True, 'is_deleted': True},
+        ],
+    )
+    def test_track_redirect__does_not_use_unrunnable_default_flow(
+        self, client, authorization, campaign, domain, write_to_db, read_from_db, ip2location_mock, default_flow_values
+    ):
+        click_id = uuid4()
+        default_flow = write_to_db(
+            'flow',
+            {
+                'name': 'Unrunnable default',
+                'campaign_id': campaign['id'],
+                'rule': None,
+                'order_value': 10,
+                'action_type': 'redirect',
+                'redirect_url': 'https://example.com/default',
+                **default_flow_values,
+            },
+        )
+        setup_response = client.patch(
+            f'/api/v2/core/campaigns/{campaign["id"]}',
+            headers={'Authorization': authorization},
+            json={'statusMapper': json.loads(campaign['status_mapper']), 'defaultFlowId': default_flow['id']},
+        )
+        assert setup_response.status_code == 200, setup_response.text
+
+        response = client.get(f'/process/{campaign["id"]}', query_string={'clickId': str(click_id)})
+
+        assert response.status_code == 200, response.text
+        assert response.text == ''
+        assert read_from_db('track_discard')['click_id'] == click_id
+
+    def test_track_redirect__does_not_use_missing_default_flow(
+        self, client, domain, campaign_payload, write_to_db, read_from_db, ip2location_mock
+    ):
+        click_id = uuid4()
+        campaign_with_missing_default = write_to_db(
+            'campaign',
+            campaign_payload | {'name': 'Missing default campaign', 'default_flow_id': 100500},
+        )
+        write_to_db(
+            'domain',
+            {
+                'hostname': 'missing-default.example.com',
+                'purpose': 'campaign',
+                'campaign_id': campaign_with_missing_default['id'],
+                'is_a_record_set': True,
+                'is_disabled': False,
+            },
+        )
+
+        response = client.get(
+            f'/process/{campaign_with_missing_default["id"]}', query_string={'clickId': str(click_id)}
+        )
+
+        assert response.status_code == 200, response.text
+        assert response.text == ''
+        assert read_from_db('track_discard')['click_id'] == click_id
+
     def test_track_redirect__tracks_discard_when_no_flow_matches(
         self, client, campaign, domain, write_to_db, read_from_db, ip2location_mock
     ):

--- a/apps/web/src/components/flows.js
+++ b/apps/web/src/components/flows.js
@@ -37,6 +37,9 @@ class Flows {
     this.onReorderCallback = vnode.attrs.onReorder;
     this.onDeleteCallback = vnode.attrs.onDelete;
     let campaignId = vnode.attrs.campaignId;
+    let defaultFlowId = vnode.attrs.defaultFlowId === ""
+      ? null
+      : Number(vnode.attrs.defaultFlowId);
 
     if (this.items.length === 0) {
       return m("div.text-muted", "No flows found.");
@@ -112,12 +115,20 @@ class Flows {
         isBusy: this.isDeleting,
         title: "Delete flow",
         body: this.deleteTarget
-          ? m(
-              "p.mb-0",
-              `Are you sure you want to delete \"${
-                this.deleteTarget.name || this.deleteTarget.id
-              }\"?`,
-            )
+          ? [
+              m(
+                "p.mb-0",
+                `Are you sure you want to delete \"${
+                  this.deleteTarget.name || this.deleteTarget.id
+                }\"?`,
+              ),
+              this.deleteTarget.id === defaultFlowId
+                ? m(
+                    "p.mt-3.mb-0.text-warning",
+                    "This flow is the campaign default. Deleting it will clear the campaign default flow.",
+                  )
+                : null,
+            ]
           : null,
         confirmText: this.isDeleting ? "Deleting..." : "Delete",
         cancelText: "Cancel",
@@ -136,7 +147,17 @@ class Flows {
 
           this.isDeleting = true;
           this.error = null;
-          this.onDeleteCallback(this.deleteTarget);
+          this.onDeleteCallback(this.deleteTarget)
+            .then(function () {
+              this.deleteTarget = null;
+            }.bind(this))
+            .catch(function () {
+              this.error = "Failed to delete flow.";
+            }.bind(this))
+            .finally(function () {
+              this.isDeleting = false;
+              m.redraw();
+            }.bind(this));
         }.bind(this),
       }),
     ]);

--- a/apps/web/src/models/core_campaign.js
+++ b/apps/web/src/models/core_campaign.js
@@ -11,11 +11,12 @@ class CoreCampaignModel {
     this.lastLoaded = null;
     this.form = {
       name: "",
-      costModel: "cpc",
+      costModel: "cpa",
       costValue: "",
       currency: "usd",
       statusMapperText: "",
       internalProcessUrl: "",
+      defaultFlowId: "",
     };
   }
 
@@ -28,6 +29,9 @@ class CoreCampaignModel {
       ? JSON.stringify(payload.statusMapper, null, 2)
       : "";
     this.form.internalProcessUrl = payload.internalProcessUrl || "";
+    this.form.defaultFlowId = payload.defaultFlowId == null
+      ? ""
+      : String(payload.defaultFlowId);
   }
 
   resetForm() {
@@ -127,13 +131,21 @@ class CoreCampaignModel {
       statusMapper = JSON.parse(statusMapperText);
     }
 
-    return {
+    let payload = {
       name: this.form.name.trim(),
       costModel: this.form.costModel,
       costValue: Number(this.form.costValue),
       currency: this.form.currency,
       statusMapper: statusMapper,
     };
+
+    if (this.campaignId !== "new") {
+      payload.defaultFlowId = this.form.defaultFlowId === ""
+        ? null
+        : Number(this.form.defaultFlowId);
+    }
+
+    return payload;
   }
 
   save() {

--- a/apps/web/src/views/core_campaign.js
+++ b/apps/web/src/views/core_campaign.js
@@ -181,6 +181,41 @@ class CoreCampaignView {
                           "JSON with parameter string and mapping object (string to string).",
                         ),
                       ]),
+                      isNew
+                        ? null
+                        : m(".mb-3", [
+                            m(
+                              "label.form-label",
+                              { for: "defaultFlowId" },
+                              "Default Flow",
+                            ),
+                            m(
+                              "select.form-select",
+                              {
+                                id: "defaultFlowId",
+                                value: this.campaignModel.form.defaultFlowId,
+                                onchange: function (event) {
+                                  this.campaignModel.form.defaultFlowId =
+                                    event.target.value;
+                                }.bind(this),
+                              },
+                              [
+                                m("option", { value: "" }, "No default flow"),
+                              ].concat(this.flowsModel.items.map(function (flow) {
+                                return m(
+                                  "option",
+                                  { value: String(flow.id) },
+                                  `${flow.name || flow.id}${
+                                    flow.isEnabled ? "" : " (disabled)"
+                                  }`,
+                                );
+                              })),
+                            ),
+                            m(
+                              ".form-text",
+                              "Served when no normal flow matches, even if the default flow rule would not match.",
+                            ),
+                          ]),
                       m(
                         "button.btn.btn-primary",
                         { type: "submit" },
@@ -223,6 +258,7 @@ class CoreCampaignView {
                   m(Flows, {
                     campaignId: this.campaignModel.campaignId,
                     flows: this.flowsModel.items,
+                    defaultFlowId: this.campaignModel.form.defaultFlowId,
                     onReorder: function (mapping) {
                       this.flowsModel.updateOrderBulk(
                         this.campaignModel.campaignId,
@@ -231,7 +267,8 @@ class CoreCampaignView {
                     }.bind(this),
                     onDelete: function (flow) {
                       return this.flowsModel.deleteFlow(flow.id).then(function () {
-                        this.flowsModel.fetch({
+                        this.campaignModel.fetch();
+                        return this.flowsModel.fetch({
                           page: 1,
                           pageSize: 1000,
                           sortBy: "orderValue",

--- a/infra/installer/install.sh
+++ b/infra/installer/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-BANGI_RELEASE_TAG="0.0.1a39"
+BANGI_RELEASE_TAG="0.0.1a40"
 BANGI_GITHUB_OWNER="devalentino"
 BANGI_GITHUB_REPO="bangi"
 BANGI_RAW_BASE_URL="https://raw.githubusercontent.com/${BANGI_GITHUB_OWNER}/${BANGI_GITHUB_REPO}/${BANGI_RELEASE_TAG}"

--- a/infra/installer/templates/compose.prod.yml
+++ b/infra/installer/templates/compose.prod.yml
@@ -1,6 +1,6 @@
 services:
   web:
-    image: ghcr.io/devalentino/bangi-web:0.0.1a39
+    image: ghcr.io/devalentino/bangi-web:0.0.1a40
     restart: always
     env_file:
       - /opt/bangi/shared/env/.env
@@ -10,7 +10,7 @@ services:
       - bangi
 
   api:
-    image: ghcr.io/devalentino/bangi-api:0.0.1a39
+    image: ghcr.io/devalentino/bangi-api:0.0.1a40
     restart: always
     env_file:
       - /opt/bangi/shared/env/.env


### PR DESCRIPTION
## Summary
- Adds campaign-level default flow support so tracking can fall back to a configured flow when no normal flow matches.
- Exposes `defaultFlowId` through campaign API responses/updates and adds dashboard controls for selecting or clearing the default flow.
- Adds alerts and validation for missing, disabled, deleted, or cross-campaign default flow configuration.
- Bumps installer and production compose images to `0.0.1a40`.

## Scope
- Included: API migration/model/schema/service changes for default flow handling, dashboard form/delete-flow updates, alert registration, and integration tests for campaign updates, alerts, and tracking fallback behavior.
- Not included: Frontend automated tests, documentation updates, or changes to flow rule authoring semantics.

## Risks
- Medium: adds a nullable campaign column and changes routing fallback behavior; existing campaigns without a default flow will continue to discard unmatched clicks, while configured defaults bypass their own rule check by design.

## Links
- Jira: KAN-9
- Spec: TBD
