### PR TITLE
KAN-55: fix: validate IP2Location country targeting availability

### DIFF
--- a/apps/api/src/alerts/enums.py
+++ b/apps/api/src/alerts/enums.py
@@ -5,6 +5,7 @@ class AlertCode(StrEnum):
     UNKNOWN = 'unknown'
     CORE_CAMPAIGN_DISCARD = 'core_campaign_discard'
     CORE_CAMPAIGN_DEFAULT_FLOW_CONFIGURATION = 'core_campaign_default_flow_configuration'
+    CORE_IP2LOCATION_DATABASE_MISSING = 'core_ip2location_database_missing'
     FACEBOOK_PACS_BUSINESS_PORTFOLIO_ACCESS_URL_MISSING = 'facebook_pacs_business_portfolio_access_url_missing'
     FACEBOOK_PACS_BUSINESS_PORTFOLIO_ACCESS_URL_EXPIRED = 'facebook_pacs_business_portfolio_access_url_expired'
     FACEBOOK_PACS_BUSINESS_PORTFOLIO_ACCESS_URL_EXPIRING_SOON = (

--- a/apps/api/src/core/alerts.py
+++ b/apps/api/src/core/alerts.py
@@ -2,6 +2,23 @@ from peewee import JOIN
 
 from src.alerts import Alert, AlertCode, AlertSeverity, register_alert_callback
 from src.core.entities import Campaign, Flow
+from src.core.services import IpLocator
+
+
+@register_alert_callback
+def collect_ip2location_alerts(container) -> list[Alert]:
+    ip_locator = container.get(IpLocator)
+    if ip_locator.is_configured():
+        return []
+
+    return [
+        Alert(
+            code=AlertCode.CORE_IP2LOCATION_DATABASE_MISSING,
+            message='Country targeting is unavailable until the IP2Location database is configured.',
+            severity=AlertSeverity.WARNING,
+            payload={'countryTargetingAvailable': False},
+        )
+    ]
 
 
 @register_alert_callback

--- a/apps/api/src/core/models.py
+++ b/apps/api/src/core/models.py
@@ -31,8 +31,8 @@ class Client:
             return ast.DataType.UNDEFINED
 
     @classmethod
-    def rule_engine_context(cls, country_available=True):
+    def rule_engine_context(cls, country_supported=True):
         type_map = {field.name: cls._rule_data_type(field.type) for field in fields(Client)}
-        if not country_available:
+        if not country_supported:
             type_map.pop('country', None)
         return Context(type_resolver=type_map, default_value=None)

--- a/apps/api/src/core/models.py
+++ b/apps/api/src/core/models.py
@@ -31,6 +31,8 @@ class Client:
             return ast.DataType.UNDEFINED
 
     @classmethod
-    def rule_engine_context(cls):
+    def rule_engine_context(cls, country_available=True):
         type_map = {field.name: cls._rule_data_type(field.type) for field in fields(Client)}
+        if not country_available:
+            type_map.pop('country', None)
         return Context(type_resolver=type_map, default_value=None)

--- a/apps/api/src/core/routes.py
+++ b/apps/api/src/core/routes.py
@@ -46,7 +46,7 @@ def _validate_flow_rule_targeting(rule, location):
         return None
 
     try:
-        rule_engine.Rule(rule, context=Client.rule_engine_context(country_available=False))
+        rule_engine.Rule(rule, context=Client.rule_engine_context(country_supported=False))
     except rule_engine.errors.SymbolResolutionError:
         return {
             'code': 422,

--- a/apps/api/src/core/routes.py
+++ b/apps/api/src/core/routes.py
@@ -1,4 +1,5 @@
 import humps
+import rule_engine
 from flask import request
 from flask.views import MethodView
 from marshmallow import ValidationError
@@ -8,6 +9,7 @@ from src.container import container
 from src.core.blueprint import Blueprint
 from src.core.enums import FlowActionType
 from src.core.exceptions import InvalidCampaignDefaultFlowError
+from src.core.models import Client
 from src.core.schemas import (
     CampaignCreateRequestSchema,
     CampaignListResponseSchema,
@@ -22,7 +24,7 @@ from src.core.schemas import (
     FlowUpdateRequestSchema,
     PaginationRequestSchema,
 )
-from src.core.services import CampaignService, FlowService
+from src.core.services import CampaignService, FlowService, IpLocator
 
 blueprint = Blueprint('core', __name__, description='Core')
 
@@ -36,6 +38,23 @@ def _campaign_summary(campaign_id, click_stats, total_click_count):
         'click_share': click_count / total_click_count if total_click_count else 0.0,
         'last_activity_at': int(last_activity_at.timestamp()) if last_activity_at else None,
     }
+
+
+def _validate_flow_rule_targeting(rule, location):
+    ip_locator = container.get(IpLocator)
+    if ip_locator.is_configured():
+        return None
+
+    try:
+        rule_engine.Rule(rule, context=Client.rule_engine_context(country_available=False))
+    except rule_engine.errors.SymbolResolutionError:
+        return {
+            'code': 422,
+            'errors': {location: {'rule': ['country targeting is unavailable until IP2Location is configured.']}},
+            'status': 'Unprocessable Entity',
+        }, 422
+
+    return None
 
 
 @blueprint.route('/campaigns')
@@ -183,6 +202,11 @@ class CampaignFlows(MethodView):
                 'status': 'Unprocessable Entity',
             }, 422
 
+        if flow_payload.get('rule') is not None:
+            targeting_error = _validate_flow_rule_targeting(flow_payload['rule'], 'form')
+            if targeting_error is not None:
+                return targeting_error
+
         flow_service = container.get(FlowService)
         flow_service.create(
             flow_payload['name'],
@@ -230,6 +254,11 @@ class Flow(MethodView):
                 'errors': {'form': {'landingArchive': e.messages}},
                 'status': 'Unprocessable Entity',
             }, 422
+
+        if flow_payload.get('rule') is not None:
+            targeting_error = _validate_flow_rule_targeting(flow_payload['rule'], 'form')
+            if targeting_error is not None:
+                return targeting_error
 
         flow_service = container.get(FlowService)
         flow_service.update(

--- a/apps/api/src/core/services.py
+++ b/apps/api/src/core/services.py
@@ -33,6 +33,9 @@ class IpLocator(Protocol):
     def get_country(self, address):
         pass
 
+    def is_configured(self):
+        pass
+
 
 @injectable(as_type=IpLocator)
 class Ip2LocationLocator:
@@ -40,8 +43,11 @@ class Ip2LocationLocator:
         self.ip2location = None
         try:
             self.ip2location = IP2Location.IP2Location(ip2location_db_path)
-        except ValueError:
+        except (TypeError, ValueError):
             logger.warning('IP2Location database is not valid')
+
+    def is_configured(self):
+        return self.ip2location is not None
 
     def get_country(self, address):
         try:
@@ -165,9 +171,11 @@ class FlowService:
         self,
         landing_pages_base_path: Annotated[str, Inject(config='LANDING_PAGES_BASE_PATH')],
         landing_renderer_base_url: Annotated[str, Inject(config='LANDING_PAGE_RENDERER_BASE_URL')],
+        ip_locator: IpLocator,
     ):
         self.landing_pages_base_path = landing_pages_base_path
         self.landing_renderer_base_url = landing_renderer_base_url
+        self.ip_locator = ip_locator
 
     def _has_index_file(self, path):
         return any(os.path.isfile(os.path.join(path, name)) for name in ('index.html', 'index.php'))
@@ -356,6 +364,14 @@ class FlowService:
             Flow.select(fn.count(Flow.id)).where((Flow.is_deleted == False) & (Flow.campaign == campaign_id)).scalar()
         )
 
+    def _matches_rule(self, flow, client):
+        try:
+            rule = rule_engine.Rule(flow.rule, context=Client.rule_engine_context(self.ip_locator.is_configured()))
+            return rule.matches(dataclasses.asdict(client))
+        except rule_engine.errors.EngineError:
+            logger.warning('Skipping non-runnable flow', exc_info=True, extra={'flow_id': flow.id})
+            return False
+
     def process_flows(self, campaign_id: int, client: Client, current_flow_id=None):
         flows = list(
             Flow.select(Flow, Campaign)
@@ -382,10 +398,8 @@ class FlowService:
             if not current_flow.show_once_per_visitor:
                 if current_flow.rule is None:
                     matched_flow = current_flow
-                else:
-                    rule = rule_engine.Rule(current_flow.rule, context=Client.rule_engine_context())
-                    if rule.matches(dataclasses.asdict(client)):
-                        matched_flow = current_flow
+                elif self._matches_rule(current_flow, client):
+                    matched_flow = current_flow
 
         if matched_flow is None:
             start_index = current_index + 1 if current_index is not None else 0
@@ -393,9 +407,7 @@ class FlowService:
                 if flow.rule is None:
                     matched_flow = flow
                     break
-
-                rule = rule_engine.Rule(flow.rule, context=Client.rule_engine_context())
-                if rule.matches(dataclasses.asdict(client)):
+                if self._matches_rule(flow, client):
                     matched_flow = flow
                     break
 

--- a/apps/api/tests/integration/conftest.py
+++ b/apps/api/tests/integration/conftest.py
@@ -57,6 +57,18 @@ def mock_subprocess_run():
 
 
 @pytest.fixture(autouse=True)
+def ip2location_configured():
+    with mock.patch('src.core.services.Ip2LocationLocator.is_configured', return_value=True):
+        yield
+
+
+@pytest.fixture
+def ip2location_unavailable():
+    with mock.patch('src.core.services.Ip2LocationLocator.is_configured', return_value=False):
+        yield
+
+
+@pytest.fixture(autouse=True)
 def assert_all_external_http_calls_are_mocked(respx_mock):
     yield
 

--- a/apps/api/tests/integration/core/test_alerts.py
+++ b/apps/api/tests/integration/core/test_alerts.py
@@ -1,3 +1,28 @@
+import pytest
+
+
+@pytest.mark.usefixtures('ip2location_unavailable')
+def test_get_alerts__returns_ip2location_database_missing_alert(
+    client, authorization, campaign, set_default_flow_id, flow
+):
+    set_default_flow_id(campaign['id'], flow['id'])
+
+    response = client.get('/api/v2/alerts', headers={'Authorization': authorization})
+
+    assert response.status_code == 200, response.text
+    assert response.json == {
+        'content': [
+            {
+                'code': 'core_ip2location_database_missing',
+                'message': 'Country targeting is unavailable until the IP2Location database is configured.',
+                'severity': 'warning',
+                'source': 'src.core.alerts',
+                'payload': {'countryTargetingAvailable': False},
+            }
+        ]
+    }
+
+
 def test_get_alerts__returns_campaign_default_flow_configuration_alert(
     client, authorization, campaign, campaign_payload, write_to_db, set_default_flow_id
 ):

--- a/apps/api/tests/integration/core/test_flows.py
+++ b/apps/api/tests/integration/core/test_flows.py
@@ -587,6 +587,30 @@ def test_create_flow__rejects_rule_with_unsupported_term(client, authorization, 
     }
 
 
+@pytest.mark.usefixtures('ip2location_unavailable')
+def test_create_flow__rejects_country_rule_when_ip2location_is_unavailable(client, authorization, campaign, flow_name):
+    response = client.post(
+        f'/api/v2/core/campaigns/{campaign["id"]}/flows',
+        headers={'Authorization': authorization},
+        data={
+            'name': flow_name,
+            'rule': 'country == "US"',
+            'actionType': 'redirect',
+            'redirectUrl': 'https://example.com',
+            'isEnabled': True,
+            'showOncePerVisitor': False,
+        },
+        content_type='multipart/form-data',
+    )
+
+    assert response.status_code == 422, response.text
+    assert response.json == {
+        'code': 422,
+        'errors': {'form': {'rule': ['country targeting is unavailable until IP2Location is configured.']}},
+        'status': 'Unprocessable Entity',
+    }
+
+
 @pytest.mark.parametrize('input_rule', ['', '   \n\t'])
 def test_create_flow__rejects_blank_rule_variations(client, authorization, campaign, input_rule):
     response = client.post(
@@ -664,6 +688,28 @@ def test_update_flow__rejects_blank_rule_variations(client, authorization, flow,
     assert response.json == {
         'code': 422,
         'errors': {'form': {'rule': ['rule cannot be blank.']}},
+        'status': 'Unprocessable Entity',
+    }
+
+
+@pytest.mark.usefixtures('ip2location_unavailable')
+def test_update_flow__rejects_country_rule_when_ip2location_is_unavailable(client, authorization, flow):
+    response = client.patch(
+        f'/api/v2/core/campaigns/{flow["campaign_id"]}/flows/{flow["id"]}',
+        headers={'Authorization': authorization},
+        data={
+            'rule': 'country == "US"',
+            'actionType': 'redirect',
+            'redirectUrl': 'https://example.org',
+            'showOncePerVisitor': False,
+        },
+        content_type='multipart/form-data',
+    )
+
+    assert response.status_code == 422, response.text
+    assert response.json == {
+        'code': 422,
+        'errors': {'form': {'rule': ['country targeting is unavailable until IP2Location is configured.']}},
         'status': 'Unprocessable Entity',
     }
 

--- a/apps/api/tests/integration/track/test_process.py
+++ b/apps/api/tests/integration/track/test_process.py
@@ -622,6 +622,42 @@ class TestTrackRedirect:
         assert response.status_code == 200, response.text
         assert response.text == ''
 
+    @pytest.mark.usefixtures('ip2location_unavailable')
+    def test_track_redirect__skips_country_rule_flow_when_ip2location_is_unavailable(
+        self, client, campaign, domain, write_to_db
+    ):
+        write_to_db(
+            'flow',
+            {
+                'name': 'Country flow',
+                'campaign_id': campaign['id'],
+                'rule': 'country == "MD"',
+                'order_value': 20,
+                'action_type': 'redirect',
+                'redirect_url': 'https://example.com/country',
+                'is_enabled': True,
+                'is_deleted': False,
+            },
+        )
+        fallback_flow = write_to_db(
+            'flow',
+            {
+                'name': 'Fallback flow',
+                'campaign_id': campaign['id'],
+                'rule': None,
+                'order_value': 10,
+                'action_type': 'redirect',
+                'redirect_url': 'https://example.com/fallback',
+                'is_enabled': True,
+                'is_deleted': False,
+            },
+        )
+
+        response = client.get(f'/process/{campaign["id"]}', query_string={'clickId': str(uuid4())})
+
+        assert response.status_code == 302, response.text
+        assert response.headers['Location'] == fallback_flow['redirect_url']
+
     def test_track_redirect__does_not_track_discard_when_flow_matches(
         self, client, campaign, domain, flow, read_from_db, ip2location_mock
     ):

--- a/infra/installer/install.sh
+++ b/infra/installer/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-BANGI_RELEASE_TAG="0.0.1a42"
+BANGI_RELEASE_TAG="0.0.1a43"
 BANGI_GITHUB_OWNER="devalentino"
 BANGI_GITHUB_REPO="bangi"
 BANGI_RAW_BASE_URL="https://raw.githubusercontent.com/${BANGI_GITHUB_OWNER}/${BANGI_GITHUB_REPO}/${BANGI_RELEASE_TAG}"

--- a/infra/installer/lib/env.sh
+++ b/infra/installer/lib/env.sh
@@ -240,14 +240,49 @@ bangi_write_ops_environment() {
         IP2LOCATION_DOWNLOAD_TOKEN
     )
     local ip2location_download_token=""
+    local token_source_locked="false"
 
     declare -gA BANGI_ENV_VALUES=()
     bangi_env_load_file "${BANGI_OPS_ENV_FILE}" BANGI_ENV_VALUES
 
-    if [[ -z "${BANGI_ENV_VALUES[IP2LOCATION_DOWNLOAD_TOKEN]+x}" || -z "${BANGI_ENV_VALUES[IP2LOCATION_DOWNLOAD_TOKEN]}" ]]; then
-        ip2location_download_token="$(bangi_env_read_ip2location_token)"
-        bangi_env_set_if_missing BANGI_ENV_VALUES IP2LOCATION_DOWNLOAD_TOKEN "${ip2location_download_token}"
+    if [[ -n "${BANGI_ENV_VALUES[IP2LOCATION_DOWNLOAD_TOKEN]+x}" ]]; then
+        ip2location_download_token="${BANGI_ENV_VALUES[IP2LOCATION_DOWNLOAD_TOKEN]}"
     fi
+
+    if [[ -n "${IP2LOCATION_DOWNLOAD_TOKEN:-}" && ! -t 0 ]]; then
+        token_source_locked="true"
+    fi
+
+    if [[ -n "${ip2location_download_token}" && -f "${BANGI_SHARED_IP2LOCATION_DIR}/${BANGI_IP2LOCATION_DATABASE_FILE}" ]]; then
+        bangi_log "IP2Location database already installed"
+    else
+        while true; do
+            if [[ -z "${ip2location_download_token}" ]]; then
+                ip2location_download_token="$(bangi_env_read_ip2location_token)"
+            fi
+
+            if [[ -z "${ip2location_download_token}" ]]; then
+                bangi_log "IP2Location setup skipped; country-based flow validation will remain unavailable until the database is configured."
+                break
+            fi
+
+            bangi_log "Validating IP2Location download token"
+            if bangi_ip2location_download_database "${ip2location_download_token}"; then
+                bangi_log "IP2Location database installed"
+                break
+            fi
+
+            if [[ "${token_source_locked}" == "true" || ! -t 0 ]]; then
+                bangi_fatal "IP2Location download token is invalid or cannot download the expected database"
+            fi
+
+            bangi_log "IP2Location download token is invalid or cannot download the expected database. Enter a new token, or leave blank to skip IP2Location setup."
+            ip2location_download_token=""
+            IP2LOCATION_DOWNLOAD_TOKEN=""
+        done
+    fi
+
+    BANGI_ENV_VALUES[IP2LOCATION_DOWNLOAD_TOKEN]="${ip2location_download_token}"
 
     bangi_env_write_file "${BANGI_OPS_ENV_FILE}" "0600" "${ops_keys[@]}"
 }

--- a/infra/installer/templates/compose.prod.yml
+++ b/infra/installer/templates/compose.prod.yml
@@ -1,6 +1,6 @@
 services:
   web:
-    image: ghcr.io/devalentino/bangi-web:0.0.1a42
+    image: ghcr.io/devalentino/bangi-web:0.0.1a43
     restart: always
     env_file:
       - /opt/bangi/shared/env/.env
@@ -10,7 +10,7 @@ services:
       - bangi
 
   api:
-    image: ghcr.io/devalentino/bangi-api:0.0.1a42
+    image: ghcr.io/devalentino/bangi-api:0.0.1a43
     restart: always
     env_file:
       - /opt/bangi/shared/env/.env


### PR DESCRIPTION
## Summary
- Validate IP2Location availability before accepting country-based flow rules.
- Skip existing country-rule flows at runtime when IP2Location is unavailable and show a global alert.
- Validate installer IP2Location tokens before persisting ops state or enabling refresh cron.

## Scope
- Included:
  - Backend IP2Location availability checks for flow create/update, `/process` selection, and alert collection.
  - Integration tests for missing IP2Location alerts, country-rule rejection, and runtime skip behavior.
  - Provisioner ops environment handling that retries invalid interactive tokens, fails invalid non-interactive tokens, and allows empty-token skip.
- Not included:
  - Firewall lifecycle, dashboard sign-in summary, show-once flows, and default-flow fallback work already handled by separate tickets.
  - Local test execution; verification is expected in CI.

## Risks
- Medium: the installer now validates tokens while materializing ops env, so hosts without network access to IP2Location will fail non-interactive token-backed setup instead of writing unusable cron state.

## Links
- Jira: https://bangitech.atlassian.net/browse/KAN-55
- Spec: https://bangitech.atlassian.net/wiki/spaces/SD/pages/12943361, https://bangitech.atlassian.net/wiki/spaces/SD/pages/12582916
