### PR TITLE
KAN-59: fix: store nginx health snapshot timestamps as Unix seconds

### DIFF
--- a/apps/api/src/domains/workers/refresh_domain_dns.py
+++ b/apps/api/src/domains/workers/refresh_domain_dns.py
@@ -105,7 +105,7 @@ def _flush_nginx_validation_snapshots(database, snapshots: list[dict[str, object
         for snapshot in snapshots
     ]
 
-    placeholders = ', '.join(['(UTC_TIMESTAMP(), %s, %s, %s, %s, %s)'] * len(rows))
+    placeholders = ', '.join(['(UNIX_TIMESTAMP(), %s, %s, %s, %s, %s)'] * len(rows))
     params: list[object] = []
     for domain_id, validation_status, validation_error, sites_available_files, sites_enabled_refs in rows:
         params.extend([domain_id, validation_status, validation_error, sites_available_files, sites_enabled_refs])

--- a/apps/api/src/domains/workers/renew_ca_certificates.py
+++ b/apps/api/src/domains/workers/renew_ca_certificates.py
@@ -94,7 +94,7 @@ def _flush_nginx_validation_snapshot(database, domain_id: int, snapshot) -> None
         (
             'INSERT INTO health_nginx_validation_snapshot '
             '(created_at, domain_id, validation_status, validation_error, sites_available_files, sites_enabled_refs) '
-            'VALUES (UTC_TIMESTAMP(), %s, %s, %s, %s, %s)'
+            'VALUES (UNIX_TIMESTAMP(), %s, %s, %s, %s, %s)'
         ),
         (
             domain_id,

--- a/apps/api/tests/integration/domains/test_certificate_renewal_worker.py
+++ b/apps/api/tests/integration/domains/test_certificate_renewal_worker.py
@@ -6,6 +6,9 @@ from unittest import mock
 import pytest
 
 
+UNIX_TIMESTAMP_YEAR_2100 = 4_102_444_800
+
+
 def _certificate_output(hostname):
     return (
         f'Your cert is in: /etc/nginx/bangi/certs/{hostname}/fullchain.pem\n'
@@ -96,6 +99,8 @@ class TestCertificateRenewalWorker:
             'sites_available_files': mock.ANY,
             'sites_enabled_refs': mock.ANY,
         }
+        assert isinstance(snapshots[-1]['created_at'], int)
+        assert snapshots[-1]['created_at'] < UNIX_TIMESTAMP_YEAR_2100
         assert json.loads(snapshots[-1]['sites_available_files']) != []
         assert json.loads(snapshots[-1]['sites_enabled_refs']) != []
 

--- a/apps/api/tests/integration/domains/test_certificate_renewal_worker.py
+++ b/apps/api/tests/integration/domains/test_certificate_renewal_worker.py
@@ -5,7 +5,6 @@ from unittest import mock
 
 import pytest
 
-
 UNIX_TIMESTAMP_YEAR_2100 = 4_102_444_800
 
 

--- a/apps/api/tests/integration/domains/test_dns_refresh.py
+++ b/apps/api/tests/integration/domains/test_dns_refresh.py
@@ -2,7 +2,6 @@ from time import sleep
 
 import pytest
 
-
 UNIX_TIMESTAMP_YEAR_2100 = 4_102_444_800
 
 

--- a/apps/api/tests/integration/domains/test_dns_refresh.py
+++ b/apps/api/tests/integration/domains/test_dns_refresh.py
@@ -3,6 +3,9 @@ from time import sleep
 import pytest
 
 
+UNIX_TIMESTAMP_YEAR_2100 = 4_102_444_800
+
+
 @pytest.mark.usefixtures('dns_resolver_mock')
 class TestDnsRefreshWorker:
     @pytest.fixture(autouse=True)
@@ -33,6 +36,8 @@ class TestDnsRefreshWorker:
         snapshot = read_from_db('health_nginx_validation_snapshot', filters={'domain_id': domain['id']})
 
         assert updated['is_a_record_set']
+        assert isinstance(snapshot['created_at'], int)
+        assert snapshot['created_at'] < UNIX_TIMESTAMP_YEAR_2100
         assert snapshot['validation_status'] == 'success'
         assert snapshot['validation_error'] is None
         assert snapshot['domain_id'] == domain['id']

--- a/infra/installer/install.sh
+++ b/infra/installer/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-BANGI_RELEASE_TAG="0.0.1a43"
+BANGI_RELEASE_TAG="0.0.1a44"
 BANGI_GITHUB_OWNER="devalentino"
 BANGI_GITHUB_REPO="bangi"
 BANGI_RAW_BASE_URL="https://raw.githubusercontent.com/${BANGI_GITHUB_OWNER}/${BANGI_GITHUB_REPO}/${BANGI_RELEASE_TAG}"

--- a/infra/installer/templates/compose.prod.yml
+++ b/infra/installer/templates/compose.prod.yml
@@ -1,6 +1,6 @@
 services:
   web:
-    image: ghcr.io/devalentino/bangi-web:0.0.1a43
+    image: ghcr.io/devalentino/bangi-web:0.0.1a44
     restart: always
     env_file:
       - /opt/bangi/shared/env/.env
@@ -10,7 +10,7 @@ services:
       - bangi
 
   api:
-    image: ghcr.io/devalentino/bangi-api:0.0.1a43
+    image: ghcr.io/devalentino/bangi-api:0.0.1a44
     restart: always
     env_file:
       - /opt/bangi/shared/env/.env


### PR DESCRIPTION
## Summary
- Store nginx validation snapshot `created_at` values as Unix timestamp seconds from raw worker SQL writes.
- Add regression assertions that worker-written snapshot timestamps stay within a sane Unix timestamp range.

## Scope
- Included: DNS refresh worker snapshot inserts, certificate renewal worker snapshot inserts, and focused integration test assertions.
- Not included: Production data repair for already corrupted `health_nginx_validation_snapshot.created_at` rows.

## Risks
- Low code risk: the change aligns raw SQL writes with the existing `UTCTimestampField` read contract. Existing corrupted rows still require operational repair before the endpoint is fully protected in production.

## Links
- Jira: https://bangitech.atlassian.net/browse/KAN-59
- Spec: TBD
