### PR TITLE
KAN-58: feat: add managed swap setup to host provisioner

### DIFF
--- a/docs/host-provisioning.md
+++ b/docs/host-provisioning.md
@@ -17,6 +17,14 @@ The installer writes the token to `/etc/bangi/ops.env`, not to the application r
 
 The installer must run as root and validates Ubuntu 24.04 LTS before any package installation phase starts.
 
+## Managed Swap
+
+Before package installation, the provisioner checks active host swap. If active swap already exists, the installer leaves it unchanged and reports the detected swap status in the completion summary.
+
+When no active swap exists and host memory is at or below `2 GB`, the installer creates a Bangi-managed `1G` swap file at `/swapfile`, secures it with `0600` permissions, enables it immediately, persists it in `/etc/fstab`, and writes Bangi swap tuning to `/etc/sysctl.d/99-bangi-swap.conf`.
+
+Hosts above the memory threshold do not receive managed swap by default. Operators can force managed swap creation by running the installer with `BANGI_SWAP_FORCE=true`.
+
 ## Host Firewall And Lifecycle
 
 The provisioner installs `iptables` and stores the canonical Bangi-managed firewall policy at `/opt/bangi/shared/firewall/iptables.rules`. The policy allows inbound TCP `22`, `80`, and `443`, allows established and loopback traffic, and drops other host inbound traffic. Production Compose keeps `web`, `api`, and `landing-renderer` bound to loopback so host Nginx remains the public edge.
@@ -71,6 +79,14 @@ For the installer skeleton, verify:
 - running on a non-Ubuntu 24.04 host fails before package installation
 - running on Ubuntu 24.04 as root reaches the installer phase orchestration
 
+For managed swap installation, verify:
+
+- on a fresh Ubuntu 24.04 host with no active swap and `2 GB` RAM or less, the installer creates `/swapfile`, sets permissions to `0600`, enables it in `swapon --show`, and writes a single `/swapfile none swap sw 0 0` entry to `/etc/fstab`
+- rerunning the installer does not duplicate the `/etc/fstab` entry or duplicate sysctl configuration in `/etc/sysctl.d/99-bangi-swap.conf`
+- on a host with existing active swap, the installer does not modify the existing swap device or file and reports it in the completion summary
+- on a host above `2 GB` RAM with no active swap, the installer does not create `/swapfile` unless `BANGI_SWAP_FORCE=true` is set
+- after reboot, `swapon --show` includes `/swapfile` when Bangi-managed swap was created
+
 For managed cron installation, verify:
 
 - `/etc/cron.d/bangi` exists after installer completion and contains a single Bangi-managed file body
@@ -83,4 +99,4 @@ For release activation and final health verification, verify:
 - forcing any required health check to fail causes the installer to exit non-zero before `/opt/bangi/current` changes
 - successful health verification checks Bangi firewall installation, `docker compose ps`, MariaDB, direct backend health, `nginx -t`, local frontend HTTP, Nginx `/api/v2/health`, and managed cron content
 - after a successful run, `/opt/bangi/current` points to `/opt/bangi/${BANGI_RELEASE_TAG}`
-- the completion summary prints the deployment bundle path, runtime and operational environment paths, compose service status, Nginx status, cron status, firewall status, detected fallback URL when public IP detection succeeds, IP2Location refresh status, and operator next steps
+- the completion summary prints the deployment bundle path, runtime and operational environment paths, compose service status, Nginx status, cron status, firewall status, swap status, detected fallback URL when public IP detection succeeds, IP2Location refresh status, and operator next steps

--- a/infra/installer/install.sh
+++ b/infra/installer/install.sh
@@ -15,6 +15,7 @@ BANGI_INSTALLER_MODULES=(
     common.sh
     os.sh
     paths.sh
+    swap.sh
     packages.sh
     assets.sh
     env.sh
@@ -89,6 +90,8 @@ bangi_bootstrap_installer_modules
 source "${INSTALLER_LIB_DIR}/os.sh"
 # shellcheck source=infra/installer/lib/paths.sh
 source "${INSTALLER_LIB_DIR}/paths.sh"
+# shellcheck source=infra/installer/lib/swap.sh
+source "${INSTALLER_LIB_DIR}/swap.sh"
 # shellcheck source=infra/installer/lib/packages.sh
 source "${INSTALLER_LIB_DIR}/packages.sh"
 # shellcheck source=infra/installer/lib/assets.sh
@@ -119,6 +122,7 @@ main() {
     bangi_log "Starting Bangi host provisioning for ${BANGI_RELEASE_TAG}"
     bangi_verify_inputs
     bangi_detect_existing_state
+    bangi_install_managed_swap
     bangi_install_packages
     bangi_create_paths
     bangi_fetch_assets

--- a/infra/installer/install.sh
+++ b/infra/installer/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-BANGI_RELEASE_TAG="0.0.1a44"
+BANGI_RELEASE_TAG="0.0.1a45"
 BANGI_GITHUB_OWNER="devalentino"
 BANGI_GITHUB_REPO="bangi"
 BANGI_RAW_BASE_URL="https://raw.githubusercontent.com/${BANGI_GITHUB_OWNER}/${BANGI_GITHUB_REPO}/${BANGI_RELEASE_TAG}"

--- a/infra/installer/lib/common.sh
+++ b/infra/installer/lib/common.sh
@@ -131,6 +131,7 @@ bangi_print_summary() {
     local cron_status="inactive"
     local firewall_status="not installed"
     local ip2location_status="not configured"
+    local swap_status="unknown"
     local fallback_host=""
 
     if systemctl is-active --quiet nginx; then
@@ -147,6 +148,12 @@ bangi_print_summary() {
         else
             firewall_status="installed; not active in current iptables INPUT chain"
         fi
+    fi
+
+    if [[ -n "${BANGI_SWAP_INSTALL_STATUS:-}" && "${BANGI_SWAP_INSTALL_STATUS}" != "not checked" ]]; then
+        swap_status="${BANGI_SWAP_INSTALL_STATUS}"
+    elif declare -F bangi_swap_active_summary >/dev/null; then
+        swap_status="$(bangi_swap_active_summary)"
     fi
 
     bangi_env_load_file "${BANGI_OPS_ENV_FILE}" ops_values
@@ -193,6 +200,7 @@ bangi_print_summary() {
     printf '  Nginx status: %s; config test passed\n' "${nginx_status}"
     printf '  Cron status: %s; managed file %s installed\n' "${cron_status}" "${BANGI_CRON_FILE}"
     printf '  Firewall status: %s; rules file %s\n' "${firewall_status}" "${BANGI_IPTABLES_RULES_FILE}"
+    printf '  Swap status: %s\n' "${swap_status}"
     if [[ -n "${fallback_host}" ]]; then
         printf '  Fallback URL: http://%s\n' "${fallback_host}"
     fi

--- a/infra/installer/lib/swap.sh
+++ b/infra/installer/lib/swap.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+
+BANGI_SWAP_FILE="${BANGI_SWAP_FILE:-/swapfile}"
+BANGI_SWAP_SIZE="${BANGI_SWAP_SIZE:-1G}"
+BANGI_SWAP_THRESHOLD_KB="${BANGI_SWAP_THRESHOLD_KB:-2097152}"
+BANGI_SWAP_SWAPPINESS="${BANGI_SWAP_SWAPPINESS:-10}"
+BANGI_SWAP_FORCE="${BANGI_SWAP_FORCE:-false}"
+BANGI_SWAP_SYSCTL_FILE="/etc/sysctl.d/99-bangi-swap.conf"
+BANGI_SWAP_FSTAB_OPTIONS="none swap sw 0 0"
+BANGI_SWAP_INSTALL_STATUS="not checked"
+
+bangi_swap_active_entries() {
+    swapon --noheadings --show=NAME,SIZE 2>/dev/null || true
+}
+
+bangi_swap_active_summary() {
+    local entries=""
+
+    entries="$(bangi_swap_active_entries)"
+    if [[ -z "${entries}" ]]; then
+        printf 'inactive'
+        return 0
+    fi
+
+    printf 'active: %s' "$(tr '\n' ';' <<<"${entries}" | sed 's/;$//')"
+}
+
+bangi_swap_host_memory_kb() {
+    awk '/^MemTotal:/ { print $2; exit }' /proc/meminfo
+}
+
+bangi_swap_should_create() {
+    local memory_kb="$1"
+
+    if [[ "${BANGI_SWAP_FORCE}" == "true" ]]; then
+        return 0
+    fi
+
+    [[ "${memory_kb}" -le "${BANGI_SWAP_THRESHOLD_KB}" ]]
+}
+
+bangi_swap_ensure_file() {
+    if [[ -f "${BANGI_SWAP_FILE}" ]]; then
+        chmod 0600 "${BANGI_SWAP_FILE}" \
+            || bangi_fatal "Cannot set secure permissions on swap file: ${BANGI_SWAP_FILE}"
+        return 0
+    fi
+
+    bangi_log "Creating Bangi-managed swap file at ${BANGI_SWAP_FILE}"
+
+    install -m 0600 -o root -g root /dev/null "${BANGI_SWAP_FILE}" \
+        || bangi_fatal "Cannot create swap file: ${BANGI_SWAP_FILE}"
+
+    if ! fallocate -l "${BANGI_SWAP_SIZE}" "${BANGI_SWAP_FILE}"; then
+        dd if=/dev/zero of="${BANGI_SWAP_FILE}" bs=1M count=1024 status=none \
+            || bangi_fatal "Cannot allocate swap file: ${BANGI_SWAP_FILE}"
+    fi
+
+    chmod 0600 "${BANGI_SWAP_FILE}" \
+        || bangi_fatal "Cannot set secure permissions on swap file: ${BANGI_SWAP_FILE}"
+    mkswap "${BANGI_SWAP_FILE}" >/dev/null \
+        || bangi_fatal "Cannot initialize swap file: ${BANGI_SWAP_FILE}"
+}
+
+bangi_swap_persist_fstab() {
+    local fstab_line="${BANGI_SWAP_FILE} ${BANGI_SWAP_FSTAB_OPTIONS}"
+
+    if awk -v swap_file="${BANGI_SWAP_FILE}" '$1 == swap_file { found = 1 } END { exit found ? 0 : 1 }' /etc/fstab; then
+        return 0
+    fi
+
+    printf '%s\n' "${fstab_line}" >>/etc/fstab \
+        || bangi_fatal "Cannot persist swap file in /etc/fstab"
+}
+
+bangi_swap_write_sysctl() {
+    local temporary_path="${BANGI_SWAP_SYSCTL_FILE}.tmp"
+
+    if ! cat >"${temporary_path}" <<EOF
+vm.swappiness=${BANGI_SWAP_SWAPPINESS}
+EOF
+    then
+        bangi_fatal "Cannot write swap sysctl configuration: ${BANGI_SWAP_SYSCTL_FILE}"
+    fi
+
+    chown root:root "${temporary_path}" \
+        || bangi_fatal "Cannot set ownership on swap sysctl configuration: ${BANGI_SWAP_SYSCTL_FILE}"
+    chmod 0644 "${temporary_path}" \
+        || bangi_fatal "Cannot set permissions on swap sysctl configuration: ${BANGI_SWAP_SYSCTL_FILE}"
+    mv -f "${temporary_path}" "${BANGI_SWAP_SYSCTL_FILE}" \
+        || bangi_fatal "Cannot install swap sysctl configuration: ${BANGI_SWAP_SYSCTL_FILE}"
+    sysctl -p "${BANGI_SWAP_SYSCTL_FILE}" >/dev/null \
+        || bangi_fatal "Cannot apply swap sysctl configuration: ${BANGI_SWAP_SYSCTL_FILE}"
+}
+
+bangi_install_managed_swap() {
+    local memory_kb=""
+
+    bangi_log "Checking host swap configuration"
+
+    if [[ -n "$(bangi_swap_active_entries)" ]]; then
+        bangi_log "Active swap detected; leaving existing swap unchanged"
+        BANGI_SWAP_INSTALL_STATUS="pre-existing; $(bangi_swap_active_summary)"
+        return 0
+    fi
+
+    memory_kb="$(bangi_swap_host_memory_kb)" \
+        || bangi_fatal "Cannot detect host memory size"
+
+    if ! bangi_swap_should_create "${memory_kb}"; then
+        bangi_log "No active swap detected; host memory ${memory_kb} KiB is above Bangi managed-swap threshold ${BANGI_SWAP_THRESHOLD_KB} KiB"
+        BANGI_SWAP_INSTALL_STATUS="not created; no active swap; host memory ${memory_kb} KiB above threshold ${BANGI_SWAP_THRESHOLD_KB} KiB"
+        return 0
+    fi
+
+    bangi_swap_ensure_file
+    swapon "${BANGI_SWAP_FILE}" \
+        || bangi_fatal "Cannot enable swap file: ${BANGI_SWAP_FILE}"
+    bangi_swap_persist_fstab
+    bangi_swap_write_sysctl
+    BANGI_SWAP_INSTALL_STATUS="created; $(bangi_swap_active_summary)"
+}

--- a/infra/installer/templates/compose.prod.yml
+++ b/infra/installer/templates/compose.prod.yml
@@ -1,6 +1,6 @@
 services:
   web:
-    image: ghcr.io/devalentino/bangi-web:0.0.1a44
+    image: ghcr.io/devalentino/bangi-web:0.0.1a45
     restart: always
     env_file:
       - /opt/bangi/shared/env/.env
@@ -10,7 +10,7 @@ services:
       - bangi
 
   api:
-    image: ghcr.io/devalentino/bangi-api:0.0.1a44
+    image: ghcr.io/devalentino/bangi-api:0.0.1a45
     restart: always
     env_file:
       - /opt/bangi/shared/env/.env


### PR DESCRIPTION
## Summary
- Add a managed swap phase to the host provisioner before package installation.
- Create and enable a conservative /swapfile on <=2 GB hosts with no active swap, while preserving operator-managed swap.
- Report swap status in the final installer summary and document manual verification steps.

## Scope
- Included: installer module bootstrap/orchestration, managed swap creation and persistence, swappiness sysctl config, final summary status, host provisioning docs.
- Not included: resizing/removing existing swap, broader memory tuning, changing documented minimum host sizing, local installer execution.

## Risks
- Moderate operational risk because this touches host-level swap, /etc/fstab, and sysctl state. The implementation is conservative: it exits early when active swap exists and writes only Bangi-managed sysctl configuration.

## Links
- Jira: https://bangitech.atlassian.net/browse/KAN-58
- Spec: https://bangitech.atlassian.net/wiki/spaces/SD/pages/8060929/Host+Provisioner+-+Functional+Spec, https://bangitech.atlassian.net/wiki/spaces/SD/pages/8093698/Host+Provisioner+-+Technical+Spec
