### PR TITLE
KAN-61: feat: keep show-once flow sticky for 24h

### DIFF
--- a/apps/api/migrations/014_domain_cookie_encryption_key.py
+++ b/apps/api/migrations/014_domain_cookie_encryption_key.py
@@ -1,0 +1,22 @@
+"""Peewee migrations -- 014_domain_cookie_encryption_key.py."""
+
+from contextlib import suppress
+
+import peewee as pw
+from peewee_migrate import Migrator
+
+
+with suppress(ImportError):
+    import playhouse.postgres_ext as pw_pext
+
+
+def migrate(migrator: Migrator, database: pw.Database, *, fake=False):
+    """Write your migrations here."""
+
+    migrator.add_fields('domain_cookie', encryption_key=pw.CharField(max_length=64, null=True))
+
+
+def rollback(migrator: Migrator, database: pw.Database, *, fake=False):
+    """Write your rollback migrations here."""
+
+    migrator.remove_fields('domain_cookie', 'encryption_key')

--- a/apps/api/requirements-dev.txt
+++ b/apps/api/requirements-dev.txt
@@ -1,6 +1,7 @@
 black==25.12.0
 flake8==7.3.0
 isort==7.0.0
+pybase62>=1.0.0
 pytest>=8.4.1
 pytest-dotenv>=0.5.2
 pytest-mysql>=3.1.0

--- a/apps/api/requirements.txt
+++ b/apps/api/requirements.txt
@@ -2,6 +2,7 @@ flask>=3.1.1
 flask-cors>=6.0.1
 flask-httpauth>=4.8.0
 flask-smorest>=0.46.1
+cryptography>=42.0.0
 httpx==0.28.1
 gunicorn>=23.0.0
 dnspython>=2.8.0

--- a/apps/api/src/core/services.py
+++ b/apps/api/src/core/services.py
@@ -372,7 +372,7 @@ class FlowService:
             logger.warning('Skipping non-runnable flow', exc_info=True, extra={'flow_id': flow.id})
             return False
 
-    def process_flows(self, campaign_id: int, client: Client, current_flow_id=None):
+    def process_flows(self, campaign_id: int, client: Client, current_flow_id=None, force_stickiness=False):
         flows = list(
             Flow.select(Flow, Campaign)
             .join(Campaign)
@@ -395,7 +395,7 @@ class FlowService:
         matched_flow = None
         if current_index is not None:
             current_flow = flows[current_index]
-            if not current_flow.show_once_per_visitor:
+            if not current_flow.show_once_per_visitor or force_stickiness:
                 if current_flow.rule is None:
                     matched_flow = current_flow
                 elif self._matches_rule(current_flow, client):

--- a/apps/api/src/core/utils.py
+++ b/apps/api/src/core/utils.py
@@ -1,9 +1,16 @@
 import logging
+import secrets
+import string
 from datetime import datetime, timezone
 from functools import wraps
 from time import perf_counter
 
+from cryptography.exceptions import InvalidTag
+from cryptography.hazmat.primitives.ciphers.aead import ChaCha20Poly1305
+
 logger = logging.getLogger(__name__)
+BASE62_ALPHABET = string.digits + string.ascii_uppercase + string.ascii_lowercase
+SEALED_BYTES_VERSION = 1
 
 
 def camelcase(s):
@@ -13,6 +20,57 @@ def camelcase(s):
 
 def utcnow():
     return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+def base62_encode(payload: bytes) -> str:
+    value = int.from_bytes(payload, byteorder='big')
+    leading_zero_count = len(payload) - len(payload.lstrip(b'\0'))
+    encoded = ''
+    while value:
+        value, remainder = divmod(value, 62)
+        encoded = BASE62_ALPHABET[remainder] + encoded
+
+    return BASE62_ALPHABET[0] * leading_zero_count + encoded
+
+
+def base62_decode(encoded_value: str) -> bytes:
+    leading_zero_count = len(encoded_value) - len(encoded_value.lstrip(BASE62_ALPHABET[0]))
+    value = 0
+    for char in encoded_value[leading_zero_count:]:
+        value = value * 62 + BASE62_ALPHABET.index(char)
+
+    payload = value.to_bytes((value.bit_length() + 7) // 8, byteorder='big') if value else b''
+    return b'\0' * leading_zero_count + payload
+
+
+def encrypt_bytes(payload: bytes, key: bytes) -> bytes:
+    nonce = secrets.token_bytes(12)
+    padding = secrets.token_bytes(secrets.randbelow(16))
+    plaintext = bytes([SEALED_BYTES_VERSION]) + bytes([len(padding)]) + padding + payload
+    ciphertext = ChaCha20Poly1305(key).encrypt(nonce, plaintext, None)
+    return nonce + ciphertext
+
+
+def decrypt_bytes(encrypted_payload: bytes, key: bytes) -> bytes | None:
+    if not encrypted_payload:
+        return None
+
+    try:
+        if len(encrypted_payload) < 12 + 16 + 2:
+            return None
+        nonce = encrypted_payload[:12]
+        ciphertext = encrypted_payload[12:]
+        plaintext = ChaCha20Poly1305(key).decrypt(nonce, ciphertext, None)
+        if len(plaintext) < 2:
+            return None
+        version = plaintext[0]
+        padding_len = plaintext[1]
+        value_offset = 2 + padding_len
+        if version != SEALED_BYTES_VERSION or len(plaintext) < value_offset:
+            return None
+        return plaintext[value_offset:]
+    except (InvalidTag, ValueError, TypeError):
+        return None
 
 
 def log_execution_time(func):

--- a/apps/api/src/domains/entities.py
+++ b/apps/api/src/domains/entities.py
@@ -19,6 +19,7 @@ class DomainCookie(Entity):
     domain = ForeignKeyField(Domain, on_delete='CASCADE')
     name = CharField(max_length=64)
     opaque_name = CharField(max_length=64)
+    encryption_key = CharField(max_length=64, null=True)
 
     class Meta:
         table_name = 'domain_cookie'

--- a/apps/api/src/domains/enums.py
+++ b/apps/api/src/domains/enums.py
@@ -8,6 +8,7 @@ class DomainPurpose(str, Enum):
 
 class DomainCookieName(str, Enum):
     flow_id = 'flow_id'
+    flow_timestamp = 'flow_timestamp'
 
 
 class DomainSortBy(str, Enum):

--- a/apps/api/src/domains/exceptions.py
+++ b/apps/api/src/domains/exceptions.py
@@ -14,6 +14,14 @@ class DomainCertificateDoesNotExistError(DoesNotExistError):
     message = 'Domain certificate does not exist'
 
 
+class EncryptionKeyDoesNotExistError(DoesNotExistError):
+    message = 'Encryption key does not exist'
+
+
+class DomainCookieDecodeError(ApplicationError):
+    message = 'Domain cookie decode failed'
+
+
 class CampaignAlreadyBoundError(ApplicationError):
     http_status_code = 400
     message = 'Campaign is already attached to a domain'

--- a/apps/api/src/domains/services.py
+++ b/apps/api/src/domains/services.py
@@ -8,6 +8,7 @@ import subprocess
 import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
+from functools import lru_cache
 from pathlib import Path
 from typing import Annotated, Protocol
 from uuid import uuid4
@@ -20,6 +21,7 @@ from wireup import Inject, injectable
 from src.core.entities import Campaign
 from src.core.enums import SortOrder
 from src.core.exceptions import CampaignDoesNotExistError
+from src.core.utils import base62_decode, base62_encode, decrypt_bytes, encrypt_bytes
 from src.domains.entities import Domain, DomainCertificate, DomainCookie
 from src.domains.enums import (
     DomainCertificateCa,
@@ -33,7 +35,9 @@ from src.domains.exceptions import (
     DashboardDomainCannotAttachCampaignError,
     DomainAlreadyExistsError,
     DomainCertificateDoesNotExistError,
+    DomainCookieDecodeError,
     DomainDoesNotExistError,
+    EncryptionKeyDoesNotExistError,
 )
 from src.health.services import HealthService
 
@@ -62,27 +66,71 @@ class AcmeExecutionSnapshot:
 
 @injectable
 class DomainCookieService:
-    def get_or_create_opaque_name(self, domain_id: int, name: DomainCookieName) -> str:
-        cookie_name = name.value
-        cookie = DomainCookie.get_or_none((DomainCookie.domain == domain_id) & (DomainCookie.name == cookie_name))
-        if cookie is not None:
-            return cookie.opaque_name
+    _ENCRYPTED_COOKIE_NAMES = frozenset({DomainCookieName.flow_timestamp})
 
+    def get_or_create_opaque_name(self, domain_id: int, name: DomainCookieName) -> str:
+        return self._get_or_create_cookie(domain_id, name).opaque_name
+
+    def seal_cookie_value(self, domain_id: int, name: DomainCookieName, value: bytes) -> str:
+        cookie = self._get_cookie(domain_id, name)
+        if cookie is None or not cookie.encryption_key:
+            raise EncryptionKeyDoesNotExistError()
+
+        encrypted_value = encrypt_bytes(value, bytes.fromhex(cookie.encryption_key))
+        return base62_encode(encrypted_value)
+
+    def open_cookie_value(
+        self,
+        domain_id: int,
+        name: DomainCookieName,
+        encoded_value: str,
+    ) -> bytes | None:
+        cookie = self._get_cookie(domain_id, name)
+        if cookie is None or not cookie.encryption_key:
+            raise EncryptionKeyDoesNotExistError()
+
+        try:
+            encrypted_value = base62_decode(encoded_value)
+        except ValueError:
+            raise DomainCookieDecodeError()
+
+        decrypted_value = decrypt_bytes(encrypted_value, bytes.fromhex(cookie.encryption_key))
+        if decrypted_value is None:
+            raise DomainCookieDecodeError()
+
+        return decrypted_value
+
+    @lru_cache
+    def _get_cookie(self, domain_id: int, name: DomainCookieName) -> DomainCookie | None:
+        return DomainCookie.get_or_none((DomainCookie.domain == domain_id) & (DomainCookie.name == name.value))
+
+    def _get_or_create_cookie(self, domain_id: int, name: DomainCookieName) -> DomainCookie:
+        cookie = self._get_cookie(domain_id, name)
+        if cookie is not None:
+            return cookie
+
+        cookie_name = name.value
         while True:
             opaque_name = self._generate_opaque_name()
+            encryption_key = secrets.token_hex(32) if name in self._ENCRYPTED_COOKIE_NAMES else None
             try:
-                cookie = DomainCookie.create(domain=domain_id, name=cookie_name, opaque_name=opaque_name)
-            except IntegrityError:
-                # Another request may have created the logical cookie row already.
-                # Re-read first; if it still does not exist, the random opaque name likely collided.
-                cookie = DomainCookie.get_or_none(
-                    (DomainCookie.domain == domain_id) & (DomainCookie.name == cookie_name)
+                cookie = DomainCookie.create(
+                    domain=domain_id,
+                    name=cookie_name,
+                    opaque_name=opaque_name,
+                    encryption_key=encryption_key,
                 )
+                self._get_cookie.cache_clear()
+                self._get_cookie(domain_id, name)
+            except IntegrityError:
+                self._get_cookie.cache_clear()
+                # A concurrent create may have inserted this logical cookie; otherwise the opaque name collided.
+                cookie = self._get_cookie(domain_id, name)
                 if cookie is not None:
-                    return cookie.opaque_name
+                    return cookie
                 continue
 
-            return cookie.opaque_name
+            return cookie
 
     @staticmethod
     def _generate_opaque_name() -> str:

--- a/apps/api/src/tracker/routes.py
+++ b/apps/api/src/tracker/routes.py
@@ -1,3 +1,5 @@
+import logging
+import time
 from uuid import uuid4
 
 from flask import make_response, redirect, request
@@ -8,6 +10,7 @@ from src.core.blueprint import Blueprint
 from src.core.enums import FlowActionType
 from src.core.services import ClientService, FlowService
 from src.domains.enums import DomainCookieName
+from src.domains.exceptions import DomainCookieDecodeError, EncryptionKeyDoesNotExistError
 from src.domains.services import DomainCookieService, DomainService
 from src.tracker.schemas import (
     TrackClickRequestSchema,
@@ -20,6 +23,9 @@ from src.tracker.services import TrackService
 
 blueprint = Blueprint('tracker', __name__, description='Tracker')
 process_blueprint = Blueprint('process', __name__, description='Tracker Process')
+FLOW_STICKY_TTL_SECONDS = 60 * 60 * 24
+COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 365
+logger = logging.getLogger(__name__)
 
 
 @blueprint.route('/click')
@@ -90,10 +96,45 @@ class Process(MethodView):
         client = client_service.client_info(
             request.user_agent.string, request.environ.get('HTTP_X_REAL_IP', request.remote_addr)
         )
-        cookie_name = cookie_service.get_or_create_opaque_name(domain.id, DomainCookieName.flow_id)
-        current_flow_payload = TrackCurrentFlowCookieSchema().load({'currentFlowId': request.cookies.get(cookie_name)})
+        flow_id_cookie_name = cookie_service.get_or_create_opaque_name(domain.id, DomainCookieName.flow_id)
+        flow_timestamp_cookie_name = cookie_service.get_or_create_opaque_name(
+            domain.id,
+            DomainCookieName.flow_timestamp,
+        )
+        current_flow_payload = TrackCurrentFlowCookieSchema().load(
+            {'currentFlowId': request.cookies.get(flow_id_cookie_name)}
+        )
+        now = int(time.time())
+        flow_timestamp_cookie_value = request.cookies.get(flow_timestamp_cookie_name)
+        sticky_started_at_payload = None
+        if flow_timestamp_cookie_value is not None:
+            try:
+                sticky_started_at_payload = cookie_service.open_cookie_value(
+                    domain.id,
+                    DomainCookieName.flow_timestamp,
+                    flow_timestamp_cookie_value,
+                )
+            except (DomainCookieDecodeError, EncryptionKeyDoesNotExistError):
+                logger.warning(
+                    'Failed to decode flow timestamp cookie',
+                    exc_info=True,
+                    extra={'domain_id': domain.id, 'cookie_name': DomainCookieName.flow_timestamp.value},
+                )
+        sticky_started_at = (
+            int.from_bytes(sticky_started_at_payload, byteorder='big', signed=False)
+            if sticky_started_at_payload is not None and len(sticky_started_at_payload) == 8
+            else None
+        )
+        flow_stickiness_not_expired = (
+            sticky_started_at is not None
+            and sticky_started_at <= now
+            and now - sticky_started_at < FLOW_STICKY_TTL_SECONDS
+        )
         action_type, subject, flow_id = flow_service.process_flows(
-            campaignId, client, current_flow_payload['currentFlowId']
+            campaignId,
+            client,
+            current_flow_payload['currentFlowId'],
+            force_stickiness=flow_stickiness_not_expired,
         )
 
         if action_type == FlowActionType.redirect:
@@ -106,11 +147,22 @@ class Process(MethodView):
 
         if flow_id is not None:
             response.set_cookie(
-                cookie_name,
+                flow_id_cookie_name,
                 str(flow_id),
                 httponly=True,
                 path='/',
-                max_age=60 * 60 * 24 * 365,
+                max_age=COOKIE_MAX_AGE_SECONDS,
+            )
+            response.set_cookie(
+                flow_timestamp_cookie_name,
+                cookie_service.seal_cookie_value(
+                    domain.id,
+                    DomainCookieName.flow_timestamp,
+                    now.to_bytes(8, byteorder='big', signed=False),
+                ),
+                httponly=True,
+                path='/',
+                max_age=COOKIE_MAX_AGE_SECONDS,
             )
 
         return response

--- a/apps/api/tests/fixtures/utils.py
+++ b/apps/api/tests/fixtures/utils.py
@@ -2,11 +2,29 @@ import time
 from datetime import datetime, timezone
 from uuid import UUID
 
+import base62
 import pytest
+from cryptography.hazmat.primitives.ciphers.aead import ChaCha20Poly1305
 
 
 def click_uuid(value):
     return UUID(f'00000000-0000-0000-0000-{value:012d}')
+
+
+def encode_flow_timestamp_cookie(timestamp, encryption_key):
+    nonce = b'testnonce123'
+    padding = b'test-padding'
+    plaintext = b'\x01' + bytes([len(padding)]) + padding + timestamp.to_bytes(8, byteorder='big', signed=False)
+    ciphertext = ChaCha20Poly1305(bytes.fromhex(encryption_key)).encrypt(nonce, plaintext, None)
+    encoded_value = base62.encodebytes(nonce + ciphertext)
+    return encoded_value.decode('ascii') if isinstance(encoded_value, bytes) else encoded_value
+
+
+def decode_flow_timestamp_cookie(cookie_value, encryption_key):
+    payload = base62.decodebytes(cookie_value)
+    plaintext = ChaCha20Poly1305(bytes.fromhex(encryption_key)).decrypt(payload[:12], payload[12:], None)
+    padding_len = plaintext[1]
+    return int.from_bytes(plaintext[2 + padding_len :], byteorder='big', signed=False)
 
 
 @pytest.fixture

--- a/apps/api/tests/integration/conftest.py
+++ b/apps/api/tests/integration/conftest.py
@@ -1,4 +1,6 @@
 import base64
+import functools
+import gc
 import os
 import pathlib
 from unittest import mock
@@ -71,6 +73,21 @@ def ip2location_unavailable():
 @pytest.fixture(autouse=True)
 def assert_all_external_http_calls_are_mocked(respx_mock):
     yield
+
+
+@pytest.fixture(autouse=True)
+def clear_lru_caches():
+    gc.collect()
+    for cached_object in gc.get_objects():
+        if isinstance(cached_object, functools._lru_cache_wrapper):
+            cached_object.cache_clear()
+
+    yield
+
+    gc.collect()
+    for cached_object in gc.get_objects():
+        if isinstance(cached_object, functools._lru_cache_wrapper):
+            cached_object.cache_clear()
 
 
 @pytest.fixture(autouse=True)

--- a/apps/api/tests/integration/domains/test_nginx.py
+++ b/apps/api/tests/integration/domains/test_nginx.py
@@ -442,6 +442,7 @@ class TestDomainNginxConfigurations:
             'domain_id': domain['id'],
             'name': 'flow_id',
             'opaque_name': mock.ANY,
+            'encryption_key': None,
         }
 
         assert len(versioned_configs) == 1
@@ -600,6 +601,7 @@ class TestDomainNginxConfigurations:
             'domain_id': domain['id'],
             'name': 'flow_id',
             'opaque_name': mock.ANY,
+            'encryption_key': None,
         }
 
         assert len(versioned_configs) == 1

--- a/apps/api/tests/integration/track/test_process.py
+++ b/apps/api/tests/integration/track/test_process.py
@@ -1,9 +1,12 @@
 import json
+import time
 from unittest import mock
 from uuid import UUID, uuid4
 
 import httpx
 import pytest
+
+from tests.fixtures.utils import decode_flow_timestamp_cookie, encode_flow_timestamp_cookie
 
 MOBILE_SAFARI_USER_AGENT = (
     'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) '
@@ -57,11 +60,11 @@ class TestTrackRedirect:
                 'show_once_per_visitor': False,
             },
         )
-        cookie_row = write_to_db(
+        cookie_flow_id = write_to_db(
             'domain_cookie',
             {'domain_id': domain['id'], 'name': 'flow_id', 'opaque_name': 'sticky_flow'},
         )
-        client.set_cookie(cookie_row['opaque_name'], str(current_flow['id']))
+        client.set_cookie(cookie_flow_id['opaque_name'], str(current_flow['id']))
 
         response = client.get(f'/process/{campaign["id"]}', query_string={'clickId': str(uuid4())})
 
@@ -113,16 +116,169 @@ class TestTrackRedirect:
                 'show_once_per_visitor': False,
             },
         )
-        cookie_row = write_to_db(
+        cookie_flow_id = write_to_db(
             'domain_cookie',
             {'domain_id': domain['id'], 'name': 'flow_id', 'opaque_name': 'sticky_flow'},
         )
-        client.set_cookie(cookie_row['opaque_name'], str(current_flow['id']))
+        client.set_cookie(cookie_flow_id['opaque_name'], str(current_flow['id']))
 
         response = client.get(f'/process/{campaign["id"]}', query_string={'clickId': str(uuid4())})
 
         assert response.status_code == 302, response.text
         assert response.headers['Location'] == next_flow['redirect_url']
+
+    def test_track_redirect__keeps_show_once_current_flow_with_valid_timestamp_cookie(
+        self, client, campaign, domain, write_to_db, ip2location_mock
+    ):
+        current_flow = write_to_db(
+            'flow',
+            {
+                'name': 'Current show-once flow',
+                'campaign_id': campaign['id'],
+                'rule': None,
+                'order_value': 20,
+                'action_type': 'redirect',
+                'redirect_url': 'https://example.com/current',
+                'is_enabled': True,
+                'is_deleted': False,
+                'show_once_per_visitor': True,
+            },
+        )
+        write_to_db(
+            'flow',
+            {
+                'name': 'Next repeatable flow',
+                'campaign_id': campaign['id'],
+                'rule': None,
+                'order_value': 10,
+                'action_type': 'redirect',
+                'redirect_url': 'https://example.com/next',
+                'is_enabled': True,
+                'is_deleted': False,
+                'show_once_per_visitor': False,
+            },
+        )
+
+        first_response = client.get(f'/process/{campaign["id"]}', query_string={'clickId': str(uuid4())})
+        assert first_response.status_code == 302, first_response.text
+        assert first_response.headers['Location'] == current_flow['redirect_url']
+
+        second_response = client.get(f'/process/{campaign["id"]}', query_string={'clickId': str(uuid4())})
+
+        assert second_response.status_code == 302, second_response.text
+        assert second_response.headers['Location'] == current_flow['redirect_url']
+
+    def test_track_redirect__skips_show_once_current_flow_after_timestamp_expires(
+        self, client, campaign, domain, write_to_db, ip2location_mock
+    ):
+        current_flow = write_to_db(
+            'flow',
+            {
+                'name': 'Current show-once flow',
+                'campaign_id': campaign['id'],
+                'rule': None,
+                'order_value': 20,
+                'action_type': 'redirect',
+                'redirect_url': 'https://example.com/current',
+                'is_enabled': True,
+                'is_deleted': False,
+                'show_once_per_visitor': True,
+            },
+        )
+        next_flow = write_to_db(
+            'flow',
+            {
+                'name': 'Next repeatable flow',
+                'campaign_id': campaign['id'],
+                'rule': None,
+                'order_value': 10,
+                'action_type': 'redirect',
+                'redirect_url': 'https://example.com/next',
+                'is_enabled': True,
+                'is_deleted': False,
+                'show_once_per_visitor': False,
+            },
+        )
+
+        flow_id_cookie_row = write_to_db(
+            'domain_cookie',
+            {'domain_id': domain['id'], 'name': 'flow_id', 'opaque_name': 'sticky_flow'},
+        )
+        timestamp_cookie_row = write_to_db(
+            'domain_cookie',
+            {
+                'domain_id': domain['id'],
+                'name': 'flow_timestamp',
+                'opaque_name': 'sticky_time',
+                'encryption_key': 'a' * 64,
+            },
+        )
+        expired_timestamp = int(time.time()) - 60 * 60 * 24
+        client.set_cookie(flow_id_cookie_row['opaque_name'], str(current_flow['id']))
+        client.set_cookie(
+            timestamp_cookie_row['opaque_name'],
+            encode_flow_timestamp_cookie(expired_timestamp, timestamp_cookie_row['encryption_key']),
+        )
+
+        second_response = client.get(f'/process/{campaign["id"]}', query_string={'clickId': str(uuid4())})
+
+        assert second_response.status_code == 302, second_response.text
+        assert second_response.headers['Location'] == next_flow['redirect_url']
+
+    @pytest.mark.parametrize('timestamp_cookie_value', ['not-base62!', '0000', '1'])
+    def test_track_redirect__malformed_timestamp_cookie_resets_when_flow_is_selected(
+        self, client, campaign, domain, write_to_db, read_from_db, ip2location_mock, timestamp_cookie_value
+    ):
+        current_flow = write_to_db(
+            'flow',
+            {
+                'name': 'Current show-once flow',
+                'campaign_id': campaign['id'],
+                'rule': None,
+                'order_value': 20,
+                'action_type': 'redirect',
+                'redirect_url': 'https://example.com/current',
+                'is_enabled': True,
+                'is_deleted': False,
+                'show_once_per_visitor': True,
+            },
+        )
+        next_flow = write_to_db(
+            'flow',
+            {
+                'name': 'Next repeatable flow',
+                'campaign_id': campaign['id'],
+                'rule': None,
+                'order_value': 10,
+                'action_type': 'redirect',
+                'redirect_url': 'https://example.com/next',
+                'is_enabled': True,
+                'is_deleted': False,
+                'show_once_per_visitor': False,
+            },
+        )
+        cookie_flow_id = write_to_db(
+            'domain_cookie',
+            {'domain_id': domain['id'], 'name': 'flow_id', 'opaque_name': 'sticky_flow'},
+        )
+        cookie_flow_timestamp = write_to_db(
+            'domain_cookie',
+            {
+                'domain_id': domain['id'],
+                'name': 'flow_timestamp',
+                'opaque_name': 'sticky_time',
+                'encryption_key': 'a' * 64,
+            },
+        )
+        client.set_cookie(cookie_flow_id['opaque_name'], str(current_flow['id']))
+        client.set_cookie(cookie_flow_timestamp['opaque_name'], timestamp_cookie_value)
+
+        response = client.get(f'/process/{campaign["id"]}', query_string={'clickId': str(uuid4())})
+
+        assert response.status_code == 302, response.text
+        assert response.headers['Location'] == next_flow['redirect_url']
+        refreshed_timestamp_cookie = client.get_cookie(cookie_flow_timestamp['opaque_name'])
+        assert refreshed_timestamp_cookie.value != timestamp_cookie_value
 
     def test_track_redirect__skips_current_flow_when_rule_no_longer_matches(
         self, client, campaign, domain, write_to_db, ip2location_mock
@@ -154,11 +310,11 @@ class TestTrackRedirect:
                 'is_deleted': False,
             },
         )
-        cookie_row = write_to_db(
+        cookie_flow_id = write_to_db(
             'domain_cookie',
             {'domain_id': domain['id'], 'name': 'flow_id', 'opaque_name': 'sticky_flow'},
         )
-        client.set_cookie(cookie_row['opaque_name'], str(current_flow['id']))
+        client.set_cookie(cookie_flow_id['opaque_name'], str(current_flow['id']))
 
         response = client.get(f'/process/{campaign["id"]}', query_string={'clickId': str(uuid4())})
 
@@ -194,11 +350,11 @@ class TestTrackRedirect:
                 'is_deleted': False,
             },
         )
-        cookie_row = write_to_db(
+        cookie_flow_id = write_to_db(
             'domain_cookie',
             {'domain_id': domain['id'], 'name': 'flow_id', 'opaque_name': 'sticky_flow'},
         )
-        client.set_cookie(cookie_row['opaque_name'], '100500')
+        client.set_cookie(cookie_flow_id['opaque_name'], '100500')
 
         response = client.get(f'/process/{campaign["id"]}', query_string={'clickId': str(uuid4())})
 
@@ -235,12 +391,12 @@ class TestTrackRedirect:
                 'is_deleted': False,
             },
         )
-        cookie_row = write_to_db(
+        cookie_flow_id = write_to_db(
             'domain_cookie',
             {'domain_id': domain['id'], 'name': 'flow_id', 'opaque_name': 'sticky_flow'},
         )
         click_id = uuid4()
-        client.set_cookie(cookie_row['opaque_name'], str(current_flow['id']))
+        client.set_cookie(cookie_flow_id['opaque_name'], str(current_flow['id']))
 
         response = client.get(f'/process/{campaign["id"]}', query_string={'clickId': str(click_id)})
 
@@ -281,11 +437,11 @@ class TestTrackRedirect:
         )
         set_default_flow_id(campaign['id'], default_flow['id'])
 
-        cookie_row = write_to_db(
+        cookie_flow_id = write_to_db(
             'domain_cookie',
             {'domain_id': domain['id'], 'name': 'flow_id', 'opaque_name': 'sticky_flow'},
         )
-        client.set_cookie(cookie_row['opaque_name'], str(default_flow['id']))
+        client.set_cookie(cookie_flow_id['opaque_name'], str(default_flow['id']))
 
         response = client.get(f'/process/{campaign["id"]}', query_string={'clickId': str(click_id)})
 
@@ -463,18 +619,43 @@ class TestTrackRedirect:
             'from': 'terraleads.com',
         }
 
+        started_at = int(time.time())
         response = client.get(f'/process/{campaign["id"]}', query_string=request_payload)
+        completed_at = int(time.time())
         assert response.status_code == 302, response.text
         assert response.headers['Location'] == flow['redirect_url']  # user gets redirected
-        cookie_row = read_from_db('domain_cookie', filters={'domain_id': domain['id'], 'name': 'flow_id'})
-        assert cookie_row == {
+        cookie_flow_id = read_from_db('domain_cookie', filters={'domain_id': domain['id'], 'name': 'flow_id'})
+        assert cookie_flow_id == {
             'id': mock.ANY,
             'created_at': mock.ANY,
             'domain_id': domain['id'],
             'name': 'flow_id',
             'opaque_name': mock.ANY,
+            'encryption_key': None,
         }
-        assert response.headers['Set-Cookie'].startswith(f'{cookie_row["opaque_name"]}={flow["id"]};')
+        flow_id_cookie = client.get_cookie(cookie_flow_id['opaque_name'])
+        assert flow_id_cookie.value == str(flow['id'])
+
+        cookie_flow_timestamp = read_from_db(
+            'domain_cookie',
+            filters={'domain_id': domain['id'], 'name': 'flow_timestamp'},
+        )
+        assert cookie_flow_timestamp == {
+            'id': mock.ANY,
+            'created_at': mock.ANY,
+            'domain_id': domain['id'],
+            'name': 'flow_timestamp',
+            'opaque_name': mock.ANY,
+            'encryption_key': mock.ANY,
+        }
+        timestamp_cookie = client.get_cookie(cookie_flow_timestamp['opaque_name'])
+        assert timestamp_cookie.value != str(flow['id'])
+        assert str(flow['id']) not in timestamp_cookie.value
+        timestamp_cookie_value = decode_flow_timestamp_cookie(
+            timestamp_cookie.value,
+            cookie_flow_timestamp['encryption_key'],
+        )
+        assert started_at <= timestamp_cookie_value <= completed_at
 
         assert ip2location_mock.get_country_short.called
 
@@ -831,20 +1012,17 @@ class TestTrackLanding:
 
         assert response.status_code == 200, response.text
         assert response.text == '<html>Sticky landing</html>'
-        cookie_row = read_from_db('domain_cookie', filters={'domain_id': domain['id'], 'name': 'flow_id'})
-        assert cookie_row == {
+        cookie_flow_id = read_from_db('domain_cookie', filters={'domain_id': domain['id'], 'name': 'flow_id'})
+        assert cookie_flow_id == {
             'id': mock.ANY,
             'created_at': mock.ANY,
             'domain_id': domain['id'],
             'name': 'flow_id',
             'opaque_name': mock.ANY,
+            'encryption_key': None,
         }
-        cookie_header = response.headers['Set-Cookie']
-        assert cookie_row['opaque_name'] in cookie_header
-        assert f'={render_flow["id"]}' in cookie_header
-        assert 'HttpOnly' in cookie_header
-        assert 'Max-Age=31536000' in cookie_header
-        assert 'Path=/' in cookie_header
+        flow_id_cookie = client.get_cookie(cookie_flow_id['opaque_name'])
+        assert flow_id_cookie.value == str(render_flow['id'])
 
     def test_track_landing__returns_404_when_campaign_domain_is_missing(self, client, campaign, read_from_db):
         response = client.get(f'/process/{campaign["id"]}', query_string={'clickId': str(uuid4())})

--- a/apps/api/tests/integration/track/test_process.py
+++ b/apps/api/tests/integration/track/test_process.py
@@ -649,8 +649,6 @@ class TestTrackRedirect:
             'encryption_key': mock.ANY,
         }
         timestamp_cookie = client.get_cookie(cookie_flow_timestamp['opaque_name'])
-        assert timestamp_cookie.value != str(flow['id'])
-        assert str(flow['id']) not in timestamp_cookie.value
         timestamp_cookie_value = decode_flow_timestamp_cookie(
             timestamp_cookie.value,
             cookie_flow_timestamp['encryption_key'],

--- a/infra/installer/install.sh
+++ b/infra/installer/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-BANGI_RELEASE_TAG="0.0.1a45"
+BANGI_RELEASE_TAG="0.0.1a46"
 BANGI_GITHUB_OWNER="devalentino"
 BANGI_GITHUB_REPO="bangi"
 BANGI_RAW_BASE_URL="https://raw.githubusercontent.com/${BANGI_GITHUB_OWNER}/${BANGI_GITHUB_REPO}/${BANGI_RELEASE_TAG}"

--- a/infra/installer/templates/compose.prod.yml
+++ b/infra/installer/templates/compose.prod.yml
@@ -1,6 +1,6 @@
 services:
   web:
-    image: ghcr.io/devalentino/bangi-web:0.0.1a45
+    image: ghcr.io/devalentino/bangi-web:0.0.1a46
     restart: always
     env_file:
       - /opt/bangi/shared/env/.env
@@ -10,7 +10,7 @@ services:
       - bangi
 
   api:
-    image: ghcr.io/devalentino/bangi-api:0.0.1a45
+    image: ghcr.io/devalentino/bangi-api:0.0.1a46
     restart: always
     env_file:
       - /opt/bangi/shared/env/.env


### PR DESCRIPTION
## Summary
- Adds a separate opaque `flow_timestamp` domain cookie so the existing raw `flow_id` cookie remains unchanged for nginx routing.
- Preserves `show_once_per_visitor` flow stickiness for 24 hours when the raw flow id and encrypted timestamp cookie are valid.
- Adds cookie encryption/base62 utilities, domain cookie key storage, migration, and integration coverage for sticky, expired, malformed, and nginx routing behavior.

## Scope
- Included: API/domain cookie model and migration, `/process` cookie handling, flow progression stickiness override, cookie crypto utilities, requirements updates, and integration tests for tracker and nginx behavior.
- Not included: managed nginx routing changes beyond verifying it still uses only raw `flow_id`; frontend/dashboard changes; local test execution.

## Risks
- Moderate: cookie decode/key handling is on the hot `/process` path and adds a nullable DB column plus encrypted cookie parsing. Decode failures are logged and treated as no sticky override.

## Links
- Jira: https://bangitech.atlassian.net/browse/KAN-61
- Spec: https://bangitech.atlassian.net/browse/KAN-61
