### PR TITLE
KAN-63: fix: remove landing path from flow responses and UI

### DIFF
--- a/apps/api/src/core/routes.py
+++ b/apps/api/src/core/routes.py
@@ -7,7 +7,6 @@ from marshmallow import ValidationError
 from src.auth import auth
 from src.container import container
 from src.core.blueprint import Blueprint
-from src.core.enums import FlowActionType
 from src.core.exceptions import InvalidCampaignDefaultFlowError
 from src.core.models import Client
 from src.core.schemas import (
@@ -175,11 +174,6 @@ class CampaignFlows(MethodView):
                     | {
                         'campaign_id': f.campaign.id,
                         'campaign_name': f.campaign.name,
-                        'landing_path': (
-                            f'{container.config.get("LANDING_PAGES_BASE_PATH")}/{f.id}'
-                            if f.action_type == FlowActionType.render
-                            else None
-                        ),
                     }
                 )
                 for f in flows
@@ -232,11 +226,6 @@ class Flow(MethodView):
             | {
                 'campaign_id': flow.campaign.id,
                 'campaign_name': flow.campaign.name,
-                'landing_path': (
-                    f'{container.config.get("LANDING_PAGES_BASE_PATH")}/{flow.id}'
-                    if flow.action_type == FlowActionType.render
-                    else None
-                ),
             }
         )
 

--- a/apps/api/src/core/schemas.py
+++ b/apps/api/src/core/schemas.py
@@ -187,7 +187,6 @@ class FlowResponseSchema(Schema):
     orderValue = fields.Integer(required=True)
     actionType = fields.String(required=True)
     redirectUrl = fields.String(allow_none=True)
-    landingPath = fields.String(allow_none=True)
     isEnabled = fields.Boolean(required=True)
     showOncePerVisitor = fields.Boolean(required=True)
     rule = fields.String(required=True, allow_none=True)

--- a/apps/api/tests/integration/core/test_flows.py
+++ b/apps/api/tests/integration/core/test_flows.py
@@ -83,7 +83,6 @@ def test_flows_list(client, authorization, campaign, flow_rule, write_to_db):
                 'orderValue': index + 1,
                 'actionType': 'redirect',
                 'redirectUrl': f'https://example.com/{index}',
-                'landingPath': None,
                 'isEnabled': True,
                 'showOncePerVisitor': False,
             }
@@ -144,7 +143,6 @@ def test_flows_list__filters_by_campaign(client, authorization, campaign, campai
                 'orderValue': index + 1,
                 'actionType': 'redirect',
                 'redirectUrl': f'https://example.com/{index}',
-                'landingPath': None,
                 'isEnabled': True,
                 'showOncePerVisitor': False,
             }
@@ -215,7 +213,6 @@ def test_flows_list__ordered_by_order_value_desc(client, authorization, campaign
                 'orderValue': third['order_value'],
                 'actionType': third['action_type'],
                 'redirectUrl': third['redirect_url'],
-                'landingPath': mock.ANY,
                 'isEnabled': third['is_enabled'],
                 'showOncePerVisitor': False,
             },
@@ -228,7 +225,6 @@ def test_flows_list__ordered_by_order_value_desc(client, authorization, campaign
                 'orderValue': first['order_value'],
                 'actionType': first['action_type'],
                 'redirectUrl': first['redirect_url'],
-                'landingPath': mock.ANY,
                 'isEnabled': first['is_enabled'],
                 'showOncePerVisitor': False,
             },
@@ -241,7 +237,6 @@ def test_flows_list__ordered_by_order_value_desc(client, authorization, campaign
                 'orderValue': second['order_value'],
                 'actionType': second['action_type'],
                 'redirectUrl': second['redirect_url'],
-                'landingPath': mock.ANY,
                 'isEnabled': second['is_enabled'],
                 'showOncePerVisitor': False,
             },
@@ -279,6 +274,47 @@ def test_flows_list__filter_out_deleted(client, authorization, campaign, flow_ru
     }
 
 
+def test_flows_list__render_action_response_format(client, authorization, campaign, flow_rule, write_to_db):
+    flow = write_to_db(
+        'flow',
+        {
+            'name': 'Render Flow',
+            'campaign_id': campaign['id'],
+            'rule': flow_rule,
+            'order_value': 1,
+            'action_type': 'render',
+            'redirect_url': None,
+            'is_enabled': True,
+            'is_deleted': False,
+            'show_once_per_visitor': False,
+        },
+    )
+
+    response = client.get(
+        f'/api/v2/core/campaigns/{campaign["id"]}/flows',
+        headers={'Authorization': authorization},
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json == {
+        'content': [
+            {
+                'id': flow['id'],
+                'name': flow['name'],
+                'campaignId': flow['campaign_id'],
+                'campaignName': campaign['name'],
+                'rule': flow_rule,
+                'orderValue': flow['order_value'],
+                'actionType': flow['action_type'],
+                'redirectUrl': None,
+                'isEnabled': True,
+                'showOncePerVisitor': False,
+            }
+        ],
+        'pagination': {'page': 1, 'pageSize': 20, 'sortBy': 'id', 'sortOrder': 'asc', 'total': 1},
+    }
+
+
 def test_get_flow(client, authorization, campaign, flow):
     response = client.get(
         f'/api/v2/core/campaigns/{campaign["id"]}/flows/{flow["id"]}',
@@ -295,8 +331,43 @@ def test_get_flow(client, authorization, campaign, flow):
         'orderValue': flow['order_value'],
         'actionType': flow['action_type'],
         'redirectUrl': flow['redirect_url'],
-        'landingPath': None,
         'isEnabled': bool(flow['is_enabled']),
+        'showOncePerVisitor': False,
+    }
+
+
+def test_get_flow__render_action_response_format(client, authorization, campaign, flow_rule, write_to_db):
+    flow = write_to_db(
+        'flow',
+        {
+            'name': 'Render Flow',
+            'campaign_id': campaign['id'],
+            'rule': flow_rule,
+            'order_value': 1,
+            'action_type': 'render',
+            'redirect_url': None,
+            'is_enabled': True,
+            'is_deleted': False,
+            'show_once_per_visitor': False,
+        },
+    )
+
+    response = client.get(
+        f'/api/v2/core/campaigns/{campaign["id"]}/flows/{flow["id"]}',
+        headers={'Authorization': authorization},
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json == {
+        'id': flow['id'],
+        'name': flow['name'],
+        'campaignId': flow['campaign_id'],
+        'campaignName': campaign['name'],
+        'rule': flow_rule,
+        'orderValue': flow['order_value'],
+        'actionType': flow['action_type'],
+        'redirectUrl': None,
+        'isEnabled': True,
         'showOncePerVisitor': False,
     }
 
@@ -766,7 +837,6 @@ def test_get_flow__without_rule(client, authorization, campaign, write_to_db):
         'orderValue': flow['order_value'],
         'actionType': flow['action_type'],
         'redirectUrl': flow['redirect_url'],
-        'landingPath': None,
         'isEnabled': bool(flow['is_enabled']),
         'showOncePerVisitor': False,
     }
@@ -803,7 +873,6 @@ def test_get_flow__returns_show_once_per_visitor(client, authorization, campaign
         'orderValue': flow['order_value'],
         'actionType': flow['action_type'],
         'redirectUrl': flow['redirect_url'],
-        'landingPath': None,
         'isEnabled': True,
         'showOncePerVisitor': True,
     }

--- a/apps/web/src/models/core_flow.js
+++ b/apps/web/src/models/core_flow.js
@@ -16,7 +16,6 @@ class CoreFlowModel {
       actionType: "redirect",
       redirectUrl: null,
       landingArchive: null,
-      landingPath: null,
       orderValue: null,
       isEnabled: true,
       showOncePerVisitor: false,
@@ -29,7 +28,6 @@ class CoreFlowModel {
     this.form.actionType = payload.actionType || "redirect";
     this.form.redirectUrl = payload.redirectUrl || "";
     this.form.landingArchive = null;
-    this.form.landingPath = payload.landingPath || "";
     this.form.isEnabled = payload.isEnabled ?? true;
     this.form.showOncePerVisitor = payload.showOncePerVisitor || false;
   }

--- a/apps/web/src/views/core_flow.js
+++ b/apps/web/src/views/core_flow.js
@@ -135,11 +135,6 @@ class CoreFlowView {
                                       event.target.files[0] || null;
                                   }.bind(this),
                                 }),
-                                m("label.form-label mt-3", "Landing path"),
-                                m(
-                                  "div.form-control-plaintext",
-                                  this.model.form.landingPath || "-",
-                                ),
                               ],
                         ]),
                       ]),

--- a/infra/installer/install.sh
+++ b/infra/installer/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-BANGI_RELEASE_TAG="0.0.1a48"
+BANGI_RELEASE_TAG="0.0.1a49"
 BANGI_GITHUB_OWNER="devalentino"
 BANGI_GITHUB_REPO="bangi"
 BANGI_RAW_BASE_URL="https://raw.githubusercontent.com/${BANGI_GITHUB_OWNER}/${BANGI_GITHUB_REPO}/${BANGI_RELEASE_TAG}"

--- a/infra/installer/templates/compose.prod.yml
+++ b/infra/installer/templates/compose.prod.yml
@@ -1,6 +1,6 @@
 services:
   web:
-    image: ghcr.io/devalentino/bangi-web:0.0.1a48
+    image: ghcr.io/devalentino/bangi-web:0.0.1a49
     restart: always
     env_file:
       - /opt/bangi/shared/env/.env
@@ -10,7 +10,7 @@ services:
       - bangi
 
   api:
-    image: ghcr.io/devalentino/bangi-api:0.0.1a48
+    image: ghcr.io/devalentino/bangi-api:0.0.1a49
     restart: always
     env_file:
       - /opt/bangi/shared/env/.env


### PR DESCRIPTION
## Summary
- Removes `landingPath` from flow list/detail API response contracts.
- Removes the Flow page `Landing path` field and frontend model state.
- Updates flow response-format tests, including render action payload coverage, while keeping landing asset generation behavior covered.
- Bumps installer and production image references from `0.0.1a48` to `0.0.1a49`.

## Scope
- Included:
  - Backend flow response schema and route payload changes.
  - Frontend Flow model/view cleanup for the obsolete landing path field.
  - Integration test updates for flow API response formats.
  - Installer release tag and production compose image version bump.
- Not included:
  - Landing archive upload, extraction, or serving behavior changes.
  - Nginx automation changes beyond the existing version bump.

## Risks
- Low. The change removes an exposed response/UI field, so any undocumented consumers relying on `landingPath` will need to stop reading it.

## Links
- Jira: https://bangitech.atlassian.net/browse/KAN-63
- Spec: TBD
