### PR TITLE
KAN-64: fix: persist campaign domain creation binding

### DIFF
--- a/apps/api/src/domains/routes.py
+++ b/apps/api/src/domains/routes.py
@@ -42,7 +42,12 @@ class Domains(MethodView):
     @auth.login_required
     def post(self, payload):
         domain_service = container.get(DomainService)
-        domain = domain_service.create(payload['hostname'], payload['purpose'], payload.get('isDisabled', False))
+        domain = domain_service.create(
+            payload['hostname'],
+            payload['purpose'],
+            campaign_id=payload.get('campaignId'),
+            is_disabled=payload.get('isDisabled', False),
+        )
         return humps.camelize(
             {
                 'id': domain.id,

--- a/apps/api/src/domains/schemas.py
+++ b/apps/api/src/domains/schemas.py
@@ -50,6 +50,7 @@ class DomainUpsertRequestSchema(Schema):
 
 class DomainCreateRequestSchema(DomainUpsertRequestSchema):
     purpose = fields.Enum(DomainPurpose, by_value=True, required=True)
+    campaignId = fields.Integer(allow_none=True, load_default=None)
     isDisabled = fields.Boolean(load_default=False)
 
 

--- a/apps/api/src/domains/services.py
+++ b/apps/api/src/domains/services.py
@@ -291,13 +291,21 @@ class DomainService:
     def count(self):
         return Domain.select(fn.count(Domain.id)).scalar()
 
-    def create(self, hostname, purpose, is_disabled=False):
+    def create(self, hostname, purpose, campaign_id=None, is_disabled=False):
         if Domain.select(fn.count(Domain.id)).where(Domain.hostname == hostname).scalar():
             raise DomainAlreadyExistsError()
+
+        campaign = None
+        if campaign_id is not None:
+            if purpose == DomainPurpose.dashboard:
+                raise DashboardDomainCannotAttachCampaignError()
+            self._ensure_campaign_is_available(campaign_id, None)
+            campaign = self._get_campaign(campaign_id)
 
         domain = Domain(
             hostname=hostname,
             purpose=purpose.value,
+            campaign=campaign,
             is_disabled=is_disabled,
             is_a_record_set=None,
         )

--- a/apps/api/tests/integration/domains/test_domains.py
+++ b/apps/api/tests/integration/domains/test_domains.py
@@ -38,6 +38,96 @@ class TestDomains:
         }
         assert read_from_db('domain_certificate') is None
 
+    def test_create_campaign_domain_persists_campaign_binding(self, client, authorization, campaign, read_from_db):
+        response = client.post(
+            '/api/v2/domains',
+            headers={'Authorization': authorization},
+            json={
+                'hostname': 'campaign.example.com',
+                'purpose': 'campaign',
+                'campaignId': campaign['id'],
+                'isDisabled': False,
+            },
+        )
+
+        assert response.status_code == 201, response.text
+        assert response.json == {
+            'id': mock.ANY,
+            'hostname': 'campaign.example.com',
+            'purpose': 'campaign',
+            'campaignId': campaign['id'],
+            'campaignName': campaign['name'],
+            'isARecordSet': None,
+            'isDisabled': False,
+            'certificateStatus': None,
+        }
+
+        domain = read_from_db('domain')
+        assert domain == {
+            'id': mock.ANY,
+            'created_at': mock.ANY,
+            'hostname': 'campaign.example.com',
+            'purpose': 'campaign',
+            'campaign_id': campaign['id'],
+            'is_a_record_set': None,
+            'is_disabled': False,
+        }
+
+    def test_create_dashboard_domain_rejects_campaign_binding(self, client, authorization, campaign):
+        response = client.post(
+            '/api/v2/domains',
+            headers={'Authorization': authorization},
+            json={
+                'hostname': 'dashboard.example.com',
+                'purpose': 'dashboard',
+                'campaignId': campaign['id'],
+            },
+        )
+
+        assert response.status_code == 400, response.text
+        assert response.json == {'message': 'Dashboard domains cannot be attached to campaigns'}
+
+    def test_create_campaign_domain_rejects_invalid_campaign(self, client, authorization):
+        response = client.post(
+            '/api/v2/domains',
+            headers={'Authorization': authorization},
+            json={
+                'hostname': 'campaign.example.com',
+                'purpose': 'campaign',
+                'campaignId': 100500,
+            },
+        )
+
+        assert response.status_code == 404, response.text
+        assert response.json == {'message': 'Campaign does not exist'}
+
+    def test_create_campaign_domain_rejects_duplicate_campaign_binding(
+        self, client, authorization, campaign, write_to_db
+    ):
+        write_to_db(
+            'domain',
+            {
+                'hostname': 'existing.example.com',
+                'purpose': 'campaign',
+                'campaign_id': campaign['id'],
+                'is_a_record_set': True,
+                'is_disabled': False,
+            },
+        )
+
+        response = client.post(
+            '/api/v2/domains',
+            headers={'Authorization': authorization},
+            json={
+                'hostname': 'campaign.example.com',
+                'purpose': 'campaign',
+                'campaignId': campaign['id'],
+            },
+        )
+
+        assert response.status_code == 400, response.text
+        assert response.json == {'message': 'Campaign is already attached to a domain'}
+
     def test_list_domains_returns_campaign_and_dashboard_domains(self, client, authorization, campaign, write_to_db):
         for index in range(19):
             write_to_db(

--- a/apps/api/tests/integration/domains/test_nginx.py
+++ b/apps/api/tests/integration/domains/test_nginx.py
@@ -439,6 +439,42 @@ class TestDomainNginxConfigurations:
         assert len(versioned_configs) == 1
         assert versioned_configs[0].read_text(encoding='utf-8') == expected_disabled_config(hostname)
 
+    def test_campaign_domain_created_with_campaign_writes_campaign_config(
+        self,
+        client,
+        authorization,
+        campaign,
+        nginx_workspace_base_dir,
+        read_from_db,
+    ):
+        hostname = 'campaign-created-with-binding.example.com'
+        response = client.post(
+            '/api/v2/domains',
+            headers={'Authorization': authorization},
+            json={'hostname': hostname, 'purpose': 'campaign', 'campaignId': campaign['id'], 'isDisabled': False},
+        )
+
+        assert response.status_code == 201, response.text
+        available_dir = Path(nginx_workspace_base_dir) / 'sites-available' / hostname
+        versioned_configs = sorted(available_dir.glob('*.conf'))
+        domain = read_from_db('domain', filters={'hostname': hostname})
+        cookie_row = read_from_db('domain_cookie', filters={'domain_id': domain['id'], 'name': 'flow_id'})
+        assert cookie_row == {
+            'id': mock.ANY,
+            'created_at': mock.ANY,
+            'domain_id': domain['id'],
+            'name': 'flow_id',
+            'opaque_name': mock.ANY,
+            'encryption_key': None,
+        }
+
+        assert len(versioned_configs) == 1
+        assert versioned_configs[0].read_text(encoding='utf-8') == expected_campaign_http_config(
+            hostname,
+            campaign['id'],
+            cookie_row['opaque_name'],
+        )
+
     def test_campaign_domain_exists_campaign_got_attached_writes_campaign_config(
         self,
         client,

--- a/apps/web/src/models/domain.js
+++ b/apps/web/src/models/domain.js
@@ -128,10 +128,6 @@ class DomainModel {
       purpose: this.form.purpose,
     };
 
-    if (this.domainId === "new") {
-      return payload;
-    }
-
     if (this.form.campaignId === "") {
       payload.campaignId = null;
     } else {

--- a/infra/installer/install.sh
+++ b/infra/installer/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-BANGI_RELEASE_TAG="0.0.1a49"
+BANGI_RELEASE_TAG="0.0.1a50"
 BANGI_GITHUB_OWNER="devalentino"
 BANGI_GITHUB_REPO="bangi"
 BANGI_RAW_BASE_URL="https://raw.githubusercontent.com/${BANGI_GITHUB_OWNER}/${BANGI_GITHUB_REPO}/${BANGI_RELEASE_TAG}"

--- a/infra/installer/templates/compose.prod.yml
+++ b/infra/installer/templates/compose.prod.yml
@@ -1,6 +1,6 @@
 services:
   web:
-    image: ghcr.io/devalentino/bangi-web:0.0.1a49
+    image: ghcr.io/devalentino/bangi-web:0.0.1a50
     restart: always
     env_file:
       - /opt/bangi/shared/env/.env
@@ -10,7 +10,7 @@ services:
       - bangi
 
   api:
-    image: ghcr.io/devalentino/bangi-api:0.0.1a49
+    image: ghcr.io/devalentino/bangi-api:0.0.1a50
     restart: always
     env_file:
       - /opt/bangi/shared/env/.env


### PR DESCRIPTION
## Summary
- Allows `POST /domains` to accept `campaignId` and persist the selected campaign on campaign-domain creation.
- Applies create-time campaign validation for dashboard domains, missing campaigns, and already-bound campaigns.
- Sends `campaignId` from the web new-domain form and covers create-time persistence plus initial Nginx campaign publishing in integration tests.

## Scope
- Included: backend domain create schema/route/service changes, web domain create payload update, domain create validation tests, and initial campaign Nginx publish coverage.
- Not included: database schema changes, update-domain behavior changes, or local test execution.

## Risks
- Low. The change reuses existing domain update validation rules on the create path; main risk is create payload compatibility around explicit `campaignId: null`, which is covered by existing no-campaign create behavior.

## Links
- Jira: https://bangitech.atlassian.net/browse/KAN-64
- Spec: TBD
