### PR TITLE
KAN-71: fix: allow rendering flow updates to keep existing landing

### DIFF
--- a/apps/api/src/core/routes.py
+++ b/apps/api/src/core/routes.py
@@ -174,6 +174,7 @@ class CampaignFlows(MethodView):
                     | {
                         'campaign_id': f.campaign.id,
                         'campaign_name': f.campaign.name,
+                        'has_landing_page': flow_service.has_landing_page(f.id),
                     }
                 )
                 for f in flows
@@ -226,6 +227,7 @@ class Flow(MethodView):
             | {
                 'campaign_id': flow.campaign.id,
                 'campaign_name': flow.campaign.name,
+                'has_landing_page': flow_service.has_landing_page(flow.id),
             }
         )
 
@@ -234,9 +236,15 @@ class Flow(MethodView):
     @auth.login_required
     def patch(self, flow_payload, campaignId, flowId):
         landing_archive = request.files.get('landingArchive')
+        flow_service = container.get(FlowService)
+        flow = flow_service.get(flowId, campaignId)
 
         try:
-            FlowUpdateRequestSchema.validate_render_action_type(flow_payload, landing_archive)
+            FlowUpdateRequestSchema.validate_render_action_type(
+                flow_payload,
+                landing_archive,
+                has_landing_page=flow_service.has_landing_page(flow.id),
+            )
         except ValidationError as e:
             return {
                 'code': 422,
@@ -249,7 +257,6 @@ class Flow(MethodView):
             if targeting_error is not None:
                 return targeting_error
 
-        flow_service = container.get(FlowService)
         flow_service.update(
             flowId,
             campaignId,

--- a/apps/api/src/core/schemas.py
+++ b/apps/api/src/core/schemas.py
@@ -162,11 +162,11 @@ class FlowUpdateRequestSchema(Schema):
             raise ValidationError('rule error', field_name='rule')
 
     @classmethod
-    def validate_render_action_type(cls, flow_payload, landing_archive):
+    def validate_render_action_type(cls, flow_payload, landing_archive, has_landing_page=False):
         if flow_payload.get('actionType') == FlowActionType.render:
-            if landing_archive is None:
+            if landing_archive is None and not has_landing_page:
                 raise ValidationError('landingArchive is required for render action.', field_name='landingArchive')
-            if not landing_archive.filename.endswith('.zip'):
+            if landing_archive is not None and not landing_archive.filename.endswith('.zip'):
                 raise ValidationError('landingArchive must be a .zip file.', field_name='landingArchive')
             return
 
@@ -190,6 +190,7 @@ class FlowResponseSchema(Schema):
     isEnabled = fields.Boolean(required=True)
     showOncePerVisitor = fields.Boolean(required=True)
     rule = fields.String(required=True, allow_none=True)
+    hasLandingPage = fields.Boolean(required=True)
 
 
 class FlowListResponseSchema(Schema):

--- a/apps/api/src/core/services.py
+++ b/apps/api/src/core/services.py
@@ -262,6 +262,13 @@ class FlowService:
 
         return landing_dir
 
+    def has_landing_page(self, flow_id):
+        if not self.landing_pages_base_path:
+            return False
+
+        landing_dir = os.path.join(self.landing_pages_base_path, str(flow_id))
+        return os.path.isdir(landing_dir) and self._has_index_file(landing_dir)
+
     @log_execution_time
     def render_landing_page(self, flow_id, method, query_string, headers, body):
         url = f'{self.landing_renderer_base_url}/{flow_id}/'
@@ -351,7 +358,7 @@ class FlowService:
             flow.action_type = action_type
             flow.redirect_url = redirect_url
 
-            if action_type == FlowActionType.render:
+            if action_type == FlowActionType.render and landing_archive is not None:
                 self._store_landing_archive(flow.id, landing_archive)
 
         if is_enabled is not None:

--- a/apps/api/tests/integration/conftest.py
+++ b/apps/api/tests/integration/conftest.py
@@ -3,6 +3,7 @@ import functools
 import gc
 import os
 import pathlib
+import shutil
 from unittest import mock
 
 import pytest
@@ -25,9 +26,13 @@ def public_ip():
     return '203.0.113.10'
 
 
-@pytest.fixture(autouse=True, scope='session')
+@pytest.fixture(autouse=True)
 def landing_pages_base_path(tmpdir_factory):
-    return str(tmpdir_factory.mktemp('landings'))
+    landing_pages_path = tmpdir_factory.mktemp('landings')
+
+    yield str(landing_pages_path)
+
+    shutil.rmtree(landing_pages_path, ignore_errors=True)
 
 
 @pytest.fixture(autouse=True, scope='session')

--- a/apps/api/tests/integration/core/test_flows.py
+++ b/apps/api/tests/integration/core/test_flows.py
@@ -1,5 +1,6 @@
 import io
 import pathlib
+import shutil
 import zipfile
 from unittest import mock
 
@@ -47,6 +48,42 @@ def _zip_bytes_without_index():
         zip_file.writestr('archive/js/script.js', 'console.log("ok");')
     archive.seek(0)
     return archive
+
+
+@pytest.fixture
+def existing_landing_path(flow, landing_pages_base_path):
+    landing_path = pathlib.Path(landing_pages_base_path) / str(flow['id'])
+    landing_path.mkdir()
+    (landing_path / 'index.html').write_text('<html>existing</html>')
+
+    yield landing_path
+
+    shutil.rmtree(landing_path, ignore_errors=True)
+
+
+@pytest.fixture
+def render_flow_with_landing(campaign, flow_rule, landing_pages_base_path, write_to_db):
+    flow = write_to_db(
+        'flow',
+        {
+            'name': 'Render Flow',
+            'campaign_id': campaign['id'],
+            'rule': flow_rule,
+            'order_value': 1,
+            'action_type': 'render',
+            'redirect_url': None,
+            'is_enabled': True,
+            'is_deleted': False,
+            'show_once_per_visitor': False,
+        },
+    )
+    landing_path = pathlib.Path(landing_pages_base_path) / str(flow['id'])
+    landing_path.mkdir()
+    (landing_path / 'index.html').write_text('<html></html>')
+
+    yield flow
+
+    shutil.rmtree(landing_path, ignore_errors=True)
 
 
 def test_flows_list(client, authorization, campaign, flow_rule, write_to_db):
@@ -343,27 +380,8 @@ def test_get_flow(client, authorization, campaign, flow):
     }
 
 
-def test_get_flow__render_action_response_format(
-    client, authorization, campaign, flow_rule, landing_pages_base_path, write_to_db
-):
-    flow = write_to_db(
-        'flow',
-        {
-            'name': 'Render Flow',
-            'campaign_id': campaign['id'],
-            'rule': flow_rule,
-            'order_value': 1,
-            'action_type': 'render',
-            'redirect_url': None,
-            'is_enabled': True,
-            'is_deleted': False,
-            'show_once_per_visitor': False,
-        },
-    )
-    landing_path = pathlib.Path(landing_pages_base_path) / str(flow['id'])
-    landing_path.mkdir()
-    (landing_path / 'index.html').write_text('<html></html>')
-
+def test_get_flow__render_action_response_format(client, authorization, campaign, render_flow_with_landing):
+    flow = render_flow_with_landing
     response = client.get(
         f'/api/v2/core/campaigns/{campaign["id"]}/flows/{flow["id"]}',
         headers={'Authorization': authorization},
@@ -954,12 +972,8 @@ def test_update_flow__render_action_success(
 
 
 def test_update_flow__render_action_keeps_existing_landing_without_upload(
-    client, authorization, flow, read_from_db, flow_rule, landing_pages_base_path
+    client, authorization, flow, read_from_db, flow_rule, existing_landing_path
 ):
-    landing_path = pathlib.Path(landing_pages_base_path) / str(flow['id'])
-    landing_path.mkdir()
-    (landing_path / 'index.html').write_text('<html>existing</html>')
-
     request_payload = {
         'name': 'Updated render flow',
         'rule': flow_rule,
@@ -991,16 +1005,13 @@ def test_update_flow__render_action_keeps_existing_landing_without_upload(
         'is_deleted': False,
         'show_once_per_visitor': False,
     }
-    assert (landing_path / 'index.html').read_text() == '<html>existing</html>'
+    assert (existing_landing_path / 'index.html').read_text() == '<html>existing</html>'
 
 
 def test_update_flow__render_action_replaces_existing_landing_when_uploaded(
-    client, authorization, flow, landing_pages_base_path
+    client, authorization, flow, existing_landing_path
 ):
-    landing_path = pathlib.Path(landing_pages_base_path) / str(flow['id'])
-    landing_path.mkdir()
-    (landing_path / 'index.html').write_text('<html>existing</html>')
-    (landing_path / 'stale.txt').write_text('remove me')
+    (existing_landing_path / 'stale.txt').write_text('remove me')
     uploaded_index_html = '<html>new landing</html>'
 
     response = client.patch(
@@ -1018,8 +1029,8 @@ def test_update_flow__render_action_replaces_existing_landing_when_uploaded(
     )
 
     assert response.status_code == 200, response.text
-    assert (landing_path / 'index.html').read_text() == uploaded_index_html
-    assert not (landing_path / 'stale.txt').exists()
+    assert (existing_landing_path / 'index.html').read_text() == uploaded_index_html
+    assert not (existing_landing_path / 'stale.txt').exists()
 
 
 def test_update_flow__requires_redirect_url_for_redirect_action(client, authorization, flow):

--- a/apps/api/tests/integration/core/test_flows.py
+++ b/apps/api/tests/integration/core/test_flows.py
@@ -6,10 +6,10 @@ from unittest import mock
 import pytest
 
 
-def _zip_bytes():
+def _zip_bytes(index_html='<html></html>'):
     archive = io.BytesIO()
     with zipfile.ZipFile(archive, 'w') as zip_file:
-        zip_file.writestr('index.html', '<html></html>')
+        zip_file.writestr('index.html', index_html)
     archive.seek(0)
     return archive
 
@@ -85,6 +85,7 @@ def test_flows_list(client, authorization, campaign, flow_rule, write_to_db):
                 'redirectUrl': f'https://example.com/{index}',
                 'isEnabled': True,
                 'showOncePerVisitor': False,
+                'hasLandingPage': False,
             }
             for index in range(20)
         ],
@@ -145,6 +146,7 @@ def test_flows_list__filters_by_campaign(client, authorization, campaign, campai
                 'redirectUrl': f'https://example.com/{index}',
                 'isEnabled': True,
                 'showOncePerVisitor': False,
+                'hasLandingPage': False,
             }
             for index in range(3)
         ],
@@ -215,6 +217,7 @@ def test_flows_list__ordered_by_order_value_desc(client, authorization, campaign
                 'redirectUrl': third['redirect_url'],
                 'isEnabled': third['is_enabled'],
                 'showOncePerVisitor': False,
+                'hasLandingPage': False,
             },
             {
                 'id': first['id'],
@@ -227,6 +230,7 @@ def test_flows_list__ordered_by_order_value_desc(client, authorization, campaign
                 'redirectUrl': first['redirect_url'],
                 'isEnabled': first['is_enabled'],
                 'showOncePerVisitor': False,
+                'hasLandingPage': False,
             },
             {
                 'id': second['id'],
@@ -239,6 +243,7 @@ def test_flows_list__ordered_by_order_value_desc(client, authorization, campaign
                 'redirectUrl': second['redirect_url'],
                 'isEnabled': second['is_enabled'],
                 'showOncePerVisitor': False,
+                'hasLandingPage': False,
             },
         ],
         'pagination': {'page': 1, 'pageSize': 20, 'sortBy': 'orderValue', 'sortOrder': 'desc', 'total': 3},
@@ -309,6 +314,7 @@ def test_flows_list__render_action_response_format(client, authorization, campai
                 'redirectUrl': None,
                 'isEnabled': True,
                 'showOncePerVisitor': False,
+                'hasLandingPage': False,
             }
         ],
         'pagination': {'page': 1, 'pageSize': 20, 'sortBy': 'id', 'sortOrder': 'asc', 'total': 1},
@@ -333,10 +339,13 @@ def test_get_flow(client, authorization, campaign, flow):
         'redirectUrl': flow['redirect_url'],
         'isEnabled': bool(flow['is_enabled']),
         'showOncePerVisitor': False,
+        'hasLandingPage': False,
     }
 
 
-def test_get_flow__render_action_response_format(client, authorization, campaign, flow_rule, write_to_db):
+def test_get_flow__render_action_response_format(
+    client, authorization, campaign, flow_rule, landing_pages_base_path, write_to_db
+):
     flow = write_to_db(
         'flow',
         {
@@ -351,6 +360,9 @@ def test_get_flow__render_action_response_format(client, authorization, campaign
             'show_once_per_visitor': False,
         },
     )
+    landing_path = pathlib.Path(landing_pages_base_path) / str(flow['id'])
+    landing_path.mkdir()
+    (landing_path / 'index.html').write_text('<html></html>')
 
     response = client.get(
         f'/api/v2/core/campaigns/{campaign["id"]}/flows/{flow["id"]}',
@@ -369,6 +381,7 @@ def test_get_flow__render_action_response_format(client, authorization, campaign
         'redirectUrl': None,
         'isEnabled': True,
         'showOncePerVisitor': False,
+        'hasLandingPage': True,
     }
 
 
@@ -839,6 +852,7 @@ def test_get_flow__without_rule(client, authorization, campaign, write_to_db):
         'redirectUrl': flow['redirect_url'],
         'isEnabled': bool(flow['is_enabled']),
         'showOncePerVisitor': False,
+        'hasLandingPage': False,
     }
 
 
@@ -875,6 +889,7 @@ def test_get_flow__returns_show_once_per_visitor(client, authorization, campaign
         'redirectUrl': flow['redirect_url'],
         'isEnabled': True,
         'showOncePerVisitor': True,
+        'hasLandingPage': False,
     }
 
 
@@ -936,6 +951,75 @@ def test_update_flow__render_action_success(
         'show_once_per_visitor': False,
     }
     assert (pathlib.Path(expected_landing_path) / 'index.html').exists()
+
+
+def test_update_flow__render_action_keeps_existing_landing_without_upload(
+    client, authorization, flow, read_from_db, flow_rule, landing_pages_base_path
+):
+    landing_path = pathlib.Path(landing_pages_base_path) / str(flow['id'])
+    landing_path.mkdir()
+    (landing_path / 'index.html').write_text('<html>existing</html>')
+
+    request_payload = {
+        'name': 'Updated render flow',
+        'rule': flow_rule,
+        'actionType': 'render',
+        'isEnabled': True,
+        'showOncePerVisitor': False,
+    }
+
+    response = client.patch(
+        f'/api/v2/core/campaigns/{flow["campaign_id"]}/flows/{flow["id"]}',
+        headers={'Authorization': authorization},
+        data=request_payload,
+        content_type='multipart/form-data',
+    )
+
+    assert response.status_code == 200, response.text
+
+    updated = read_from_db('flow', filters={'id': flow['id']})
+    assert updated == {
+        'id': flow['id'],
+        'name': request_payload['name'],
+        'created_at': mock.ANY,
+        'campaign_id': flow['campaign_id'],
+        'rule': request_payload['rule'],
+        'order_value': flow['order_value'],
+        'action_type': request_payload['actionType'],
+        'redirect_url': None,
+        'is_enabled': request_payload['isEnabled'],
+        'is_deleted': False,
+        'show_once_per_visitor': False,
+    }
+    assert (landing_path / 'index.html').read_text() == '<html>existing</html>'
+
+
+def test_update_flow__render_action_replaces_existing_landing_when_uploaded(
+    client, authorization, flow, landing_pages_base_path
+):
+    landing_path = pathlib.Path(landing_pages_base_path) / str(flow['id'])
+    landing_path.mkdir()
+    (landing_path / 'index.html').write_text('<html>existing</html>')
+    (landing_path / 'stale.txt').write_text('remove me')
+    uploaded_index_html = '<html>new landing</html>'
+
+    response = client.patch(
+        f'/api/v2/core/campaigns/{flow["campaign_id"]}/flows/{flow["id"]}',
+        headers={'Authorization': authorization},
+        data={
+            'name': flow['name'],
+            'rule': flow['rule'],
+            'actionType': 'render',
+            'isEnabled': True,
+            'landingArchive': (_zip_bytes(uploaded_index_html), 'landing.zip'),
+            'showOncePerVisitor': False,
+        },
+        content_type='multipart/form-data',
+    )
+
+    assert response.status_code == 200, response.text
+    assert (landing_path / 'index.html').read_text() == uploaded_index_html
+    assert not (landing_path / 'stale.txt').exists()
 
 
 def test_update_flow__requires_redirect_url_for_redirect_action(client, authorization, flow):

--- a/apps/api/tests/integration/core/test_flows.py
+++ b/apps/api/tests/integration/core/test_flows.py
@@ -1,6 +1,5 @@
 import io
 import pathlib
-import shutil
 import zipfile
 from unittest import mock
 
@@ -58,8 +57,6 @@ def existing_landing_path(flow, landing_pages_base_path):
 
     yield landing_path
 
-    shutil.rmtree(landing_path, ignore_errors=True)
-
 
 @pytest.fixture
 def render_flow_with_landing(campaign, flow_rule, landing_pages_base_path, write_to_db):
@@ -82,8 +79,6 @@ def render_flow_with_landing(campaign, flow_rule, landing_pages_base_path, write
     (landing_path / 'index.html').write_text('<html></html>')
 
     yield flow
-
-    shutil.rmtree(landing_path, ignore_errors=True)
 
 
 def test_flows_list(client, authorization, campaign, flow_rule, write_to_db):
@@ -380,7 +375,7 @@ def test_get_flow(client, authorization, campaign, flow):
     }
 
 
-def test_get_flow__render_action_response_format(client, authorization, campaign, render_flow_with_landing):
+def test_get_flow__render_action_response_format(client, authorization, campaign, flow_rule, render_flow_with_landing):
     flow = render_flow_with_landing
     response = client.get(
         f'/api/v2/core/campaigns/{campaign["id"]}/flows/{flow["id"]}',

--- a/apps/web/src/models/core_flow.js
+++ b/apps/web/src/models/core_flow.js
@@ -16,6 +16,7 @@ class CoreFlowModel {
       actionType: "redirect",
       redirectUrl: null,
       landingArchive: null,
+      hasLandingPage: false,
       orderValue: null,
       isEnabled: true,
       showOncePerVisitor: false,
@@ -28,6 +29,7 @@ class CoreFlowModel {
     this.form.actionType = payload.actionType || "redirect";
     this.form.redirectUrl = payload.redirectUrl || "";
     this.form.landingArchive = null;
+    this.form.hasLandingPage = payload.hasLandingPage || false;
     this.form.isEnabled = payload.isEnabled ?? true;
     this.form.showOncePerVisitor = payload.showOncePerVisitor || false;
   }
@@ -82,7 +84,11 @@ class CoreFlowModel {
       }
     }
 
-    if (this.form.actionType === "render" && !this.form.landingArchive) {
+    if (
+      this.form.actionType === "render" &&
+      !this.form.hasLandingPage &&
+      !this.form.landingArchive
+    ) {
       return "Landing archive is required.";
     }
 

--- a/apps/web/src/views/core_flow.js
+++ b/apps/web/src/views/core_flow.js
@@ -122,6 +122,18 @@ class CoreFlowView {
                                 }),
                               ]
                             : [
+                                this.model.form.hasLandingPage
+                                  ? m(".alert.alert-info.mb-3", [
+                                      m(
+                                        ".fw-semibold",
+                                        "Landing page already uploaded",
+                                      ),
+                                      m(
+                                        ".small.mt-1",
+                                        "Upload a new archive only if you want to replace it.",
+                                      ),
+                                    ])
+                                  : null,
                                 m(
                                   "label.form-label",
                                   { for: "renderFile" },

--- a/infra/installer/install.sh
+++ b/infra/installer/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-BANGI_RELEASE_TAG="0.0.1a52"
+BANGI_RELEASE_TAG="0.0.1a53"
 BANGI_GITHUB_OWNER="devalentino"
 BANGI_GITHUB_REPO="bangi"
 BANGI_RAW_BASE_URL="https://raw.githubusercontent.com/${BANGI_GITHUB_OWNER}/${BANGI_GITHUB_REPO}/${BANGI_RELEASE_TAG}"

--- a/infra/installer/templates/compose.prod.yml
+++ b/infra/installer/templates/compose.prod.yml
@@ -1,6 +1,6 @@
 services:
   web:
-    image: ghcr.io/devalentino/bangi-web:0.0.1a52
+    image: ghcr.io/devalentino/bangi-web:0.0.1a53
     restart: always
     env_file:
       - /opt/bangi/shared/env/.env
@@ -10,7 +10,7 @@ services:
       - bangi
 
   api:
-    image: ghcr.io/devalentino/bangi-api:0.0.1a52
+    image: ghcr.io/devalentino/bangi-api:0.0.1a53
     restart: always
     env_file:
       - /opt/bangi/shared/env/.env


### PR DESCRIPTION
## Summary
- Allows rendering-flow edits to keep an existing landing page without forcing a re-upload.
- Exposes `hasLandingPage` in flow API responses so the dashboard can show the attached landing state.
- Keeps the render file input available for optional replacement and preserves upload validation when no landing exists.
- Bumps installer/runtime image references from `0.0.1a52` to `0.0.1a53`.

## Scope
- Included: Core flow API validation/storage behavior, flow response schema/tests, dashboard render-flow edit UX, and installer image/tag version bump.
- Not included: Landing storage migration, new landing management endpoints, local test execution, or changes to unrelated untracked perf/domain test files.

## Risks
- Low to medium: `hasLandingPage` is derived from filesystem state under `LANDING_PAGES_BASE_PATH`, so environments with missing landing files will still require upload on render updates.

## Links
- Jira: https://bangitech.atlassian.net/browse/KAN-71
- Spec: TBD
