### PR TITLE
KAN-73: fix: statistics report single-day totals

### DIFF
--- a/apps/api/src/reports/services.py
+++ b/apps/api/src/reports/services.py
@@ -214,9 +214,7 @@ class ReportService:
         }
 
         date2distribution = {
-            date: sum(json.loads(distribution).values())
-            for date, distribution in expenses_rows
-            if start <= date <= end
+            date: sum(json.loads(distribution).values()) for date, distribution in expenses_rows if start <= date <= end
         }
 
         payouts_accepted = 0

--- a/apps/api/src/reports/services.py
+++ b/apps/api/src/reports/services.py
@@ -202,6 +202,7 @@ class ReportService:
         return report
 
     def _build_total(self, report_rows, expenses_rows, start, end):
+        end = end or utcnow().date()
         total = {
             'clicks': 0,
             'statuses': {s.value: {'leads': 0, 'payouts': 0} for s in LeadStatus},
@@ -215,7 +216,7 @@ class ReportService:
         date2distribution = {
             date: sum(json.loads(distribution).values())
             for date, distribution in expenses_rows
-            if date > start or date < end
+            if start <= date <= end
         }
 
         payouts_accepted = 0

--- a/apps/api/tests/integration/reports/test_statistics.py
+++ b/apps/api/tests/integration/reports/test_statistics.py
@@ -951,6 +951,65 @@ def test_get_report__zero_expenses_does_not_cause_division_by_zero(
     }
 
 
+def test_get_report__single_day_total_includes_expenses(client, authorization, campaign, statistics_expenses, today):
+    expected_expenses = sum(statistics_expenses[today].values())
+    cost_value = float(campaign['cost_value'])
+
+    response = client.get(
+        '/api/v2/reports/statistics',
+        headers={'Authorization': authorization},
+        query_string={
+            'campaignId': campaign['id'],
+            'periodStart': today.isoformat(),
+            'periodEnd': today.isoformat(),
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json == {
+        'content': {
+            'parameters': mock.ANY,
+            'groupParameters': [],
+            'report': {
+                today.isoformat(): {
+                    'expenses': pytest.approx(expected_expenses, abs=0.02),
+                    'roi_accepted': pytest.approx(
+                        (cost_value - expected_expenses) / expected_expenses * 100,
+                        abs=0.02,
+                    ),
+                    'roi_expected': pytest.approx(
+                        (cost_value - expected_expenses) / expected_expenses * 100,
+                        abs=0.02,
+                    ),
+                    'profit_accepted': pytest.approx(cost_value - expected_expenses, abs=0.02),
+                    'profit_expected': pytest.approx(cost_value - expected_expenses, abs=0.02),
+                    'statuses': {
+                        'accept': {'leads': 1, 'payouts': cost_value},
+                        'expect': {'leads': 0, 'payouts': 0},
+                        'reject': {'leads': 0, 'payouts': 0},
+                        'trash': {'leads': 0, 'payouts': 0},
+                    },
+                    'clicks': 8,
+                }
+            },
+            'total': {
+                'clicks': 8,
+                'statuses': {
+                    'accept': {'leads': 1, 'payouts': cost_value},
+                    'expect': {'leads': 0, 'payouts': 0},
+                    'reject': {'leads': 0, 'payouts': 0},
+                    'trash': {'leads': 0, 'payouts': 0},
+                },
+                'expenses': pytest.approx(expected_expenses, abs=0.02),
+                'profit_accepted': pytest.approx(cost_value - expected_expenses, abs=0.02),
+                'profit_expected': pytest.approx(cost_value - expected_expenses, abs=0.02),
+                'roi_accepted': pytest.approx((cost_value - expected_expenses) / expected_expenses * 100, abs=0.02),
+                'roi_expected': pytest.approx((cost_value - expected_expenses) / expected_expenses * 100, abs=0.02),
+            },
+        }
+    }
+
+
 def test_get_report__does_not_count_statistics_outside_filter_boundaries(
     client, authorization, campaign, write_to_db, today, click_parameters, postback_parameters
 ):

--- a/infra/installer/install.sh
+++ b/infra/installer/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-BANGI_RELEASE_TAG="0.0.1a53"
+BANGI_RELEASE_TAG="0.0.1a54"
 BANGI_GITHUB_OWNER="devalentino"
 BANGI_GITHUB_REPO="bangi"
 BANGI_RAW_BASE_URL="https://raw.githubusercontent.com/${BANGI_GITHUB_OWNER}/${BANGI_GITHUB_REPO}/${BANGI_RELEASE_TAG}"

--- a/infra/installer/templates/compose.prod.yml
+++ b/infra/installer/templates/compose.prod.yml
@@ -1,6 +1,6 @@
 services:
   web:
-    image: ghcr.io/devalentino/bangi-web:0.0.1a53
+    image: ghcr.io/devalentino/bangi-web:0.0.1a54
     restart: always
     env_file:
       - /opt/bangi/shared/env/.env
@@ -10,7 +10,7 @@ services:
       - bangi
 
   api:
-    image: ghcr.io/devalentino/bangi-api:0.0.1a53
+    image: ghcr.io/devalentino/bangi-api:0.0.1a54
     restart: always
     env_file:
       - /opt/bangi/shared/env/.env


### PR DESCRIPTION
## Summary
- Fix statistics report total calculation so a single-day range includes that day's expenses in total profit and ROI.
- Align total expense filtering with the existing inclusive click/lead date boundaries.
- Add integration coverage for `/api/v2/reports/statistics` with `periodStart == periodEnd`.
- Bump installer release references from `0.0.1a53` to `0.0.1a54`.

## Scope
- Included: Backend statistics total calculation, single-day statistics regression test, installer release tag/image references.
- Not included: Statistics table frontend changes, report row calculation changes, database schema changes.

## Risks
- Low risk for multi-day report totals: the new filter keeps in-range boundary dates included and excludes only out-of-range expense rows.
- Installer references now point to `0.0.1a54`; deployment depends on those images/assets existing.

## Links
- Jira: https://bangitech.atlassian.net/browse/KAN-73
- Spec: TBD
