### PR TITLE
KAN-74: perf: seed history for existing campaigns

### DIFF
--- a/apps/api/perf/README.md
+++ b/apps/api/perf/README.md
@@ -236,7 +236,7 @@ Render flows use the same shape with:
 
 ```bash
 EXPECTED_STATUSES=200
-EXPECTED_CONTENT_TYPE='text/html; charset=utf-8'
+EXPECTED_CONTENT_TYPE='text/html; charset=UTF-8'
 ```
 
 ## Reading Results

--- a/apps/api/perf/README.md
+++ b/apps/api/perf/README.md
@@ -38,7 +38,7 @@ Choose one setup path before running a workload.
 | Local Docker Compose | Manually through dashboard/API | Seed scripts | Local Docker artifacts plus k6 artifacts |
 | External host | Manually through dashboard/API | Seed scripts through exposed MariaDB | External server, nginx, app, and DB metrics plus k6 artifacts |
 
-Seed scripts are used to fill historical tracker data for realistic report reads. Current seed scripts also create campaign fixtures and require an empty `campaign` table, so they fit fresh performance databases. They do not create domains, nginx configs, or certificates. `KAN-74` tracks the follow-up to seed history for an already configured campaign.
+Seed scripts are used to fill historical tracker data for realistic report reads. They require an existing `CAMPAIGN_ID` and do not create campaigns, flows, domains, nginx configs, or certificates.
 
 ## Manual Environment Setup
 
@@ -80,7 +80,7 @@ Additional requirements for the process workload:
 
 ## Historical Data
 
-Historical rows make report reads more realistic. Current seed scripts fill historical tracker rows and also create the required campaign fixtures. They require an empty `campaign` table.
+Historical rows make report reads more realistic. Seed scripts fill historical tracker rows for an existing campaign.
 
 Pass DB connection settings explicitly when running seed scripts:
 
@@ -90,7 +90,7 @@ MARIADB_PORT=3306 \
 MARIADB_USER=bangi \
 MARIADB_PASSWORD='<password>' \
 MARIADB_DATABASE=bangi \
-python perf/track_and_reports_seed.py --clicks 1000000 --lead-ratio 0.15 --postback-ratio 0.85 --days 14
+python perf/track_and_reports_seed.py --campaign-id 2 --clicks 1000000 --lead-ratio 0.15 --postback-ratio 0.85 --days 14
 ```
 
 ```bash
@@ -99,12 +99,12 @@ MARIADB_PORT=3306 \
 MARIADB_USER=bangi \
 MARIADB_PASSWORD='<password>' \
 MARIADB_DATABASE=bangi \
-python perf/process_and_reports_seed.py --action-type redirect --clicks 1000000 --lead-ratio 0.30 --postback-ratio 0.85 --days 14
+python perf/process_and_reports_seed.py --campaign-id 2 --clicks 1000000 --lead-ratio 0.30 --postback-ratio 0.85 --days 14
 ```
 
 For external hosts, expose MariaDB only in a controlled performance environment. The seed scripts prompt when `MARIADB_HOST` is non-local and refuse to run without an interactive confirmation.
 
-Do not run current seed scripts against an environment with existing campaigns. Use a fresh performance database, then complete any required dashboard domain and campaign domain setup through the product path.
+Run seed scripts only against the campaign prepared for the performance test. They insert tracker rows directly and do not validate flow or domain configuration.
 
 ## Artifact Collection
 

--- a/apps/api/perf/perf_seed_common.py
+++ b/apps/api/perf/perf_seed_common.py
@@ -10,13 +10,6 @@ from uuid import UUID, uuid4
 import pymysql
 from pymysql.cursors import DictCursor
 
-PERF_CAMPAIGN_PREFIX = 'Perf Process Campaign'
-PERF_STATUS_MAPPER = {'parameter': 'state', 'mapping': {'executed': 'accept', 'failed': 'reject'}}
-PERF_COST_MODEL = 'cpa'
-PERF_COST_VALUE = 10.0
-PERF_CURRENCY = 'usd'
-
-
 def is_local_db_host(host):
     return host in {'localhost', '127.0.0.1', '::1', 'mariadb', 'docker.local'}
 
@@ -39,20 +32,6 @@ def ensure_safe_db_target():
         confirm_remote_target(host)
 
 
-def count_campaigns(cursor):
-    cursor.execute('SELECT COUNT(*) AS count FROM campaign')
-    return cursor.fetchone()['count']
-
-
-def ensure_empty_campaigns_table(cursor):
-    campaign_count = count_campaigns(cursor)
-    if campaign_count != 0:
-        raise RuntimeError(
-            f'Refusing to seed because the database already contains {campaign_count} campaign(s). '
-            'Performance seed scripts must run against an empty campaigns table.'
-        )
-
-
 def get_connection():
     return pymysql.connect(
         host=os.environ['MARIADB_HOST'],
@@ -65,30 +44,19 @@ def get_connection():
     )
 
 
-def create_campaign(cursor):
-    payload = {
-        'name': f'{PERF_CAMPAIGN_PREFIX} {datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")}',
-        'cost_model': PERF_COST_MODEL,
-        'cost_value': PERF_COST_VALUE,
-        'currency': PERF_CURRENCY,
-        'status_mapper': json.dumps(PERF_STATUS_MAPPER),
-        'expenses_distribution_parameter': None,
-        'created_at': int(datetime.now(timezone.utc).timestamp()),
-    }
+def get_campaign(cursor, campaign_id):
     cursor.execute(
         '''
-        INSERT INTO campaign (
-            name, cost_model, cost_value, currency, status_mapper, expenses_distribution_parameter, created_at
-        )
-        VALUES (
-            %(name)s, %(cost_model)s, %(cost_value)s, %(currency)s, %(status_mapper)s,
-            %(expenses_distribution_parameter)s, %(created_at)s
-        )
+        SELECT id, name, cost_value, currency
+        FROM campaign
+        WHERE id = %s
         ''',
-        payload,
+        (campaign_id,),
     )
-    payload['id'] = cursor.lastrowid
-    return payload
+    campaign = cursor.fetchone()
+    if campaign is None:
+        raise RuntimeError(f'Campaign {campaign_id} does not exist.')
+    return campaign
 
 
 def now_timestamp():

--- a/apps/api/perf/process_and_reports_seed.py
+++ b/apps/api/perf/process_and_reports_seed.py
@@ -1,48 +1,21 @@
 #!/usr/bin/env python3
 
 import argparse
-import os
-from datetime import datetime, timezone
-from pathlib import Path
 from pprint import pprint
 
 from perf_seed_common import (
-    create_campaign,
-    ensure_empty_campaigns_table,
     ensure_safe_db_target,
+    get_campaign,
     get_connection,
     print_progress,
     seed_tracker_tables,
     validate_ratio,
 )
 
-PERF_FLOW_PREFIX = 'Perf Process Flow'
-PERF_REDIRECT_URL = 'https://example.com/perf-process'
-PERF_LANDING_HTML = (
-    '<!DOCTYPE html>\n'
-    '<html lang="en">\n'
-    '<head>\n'
-    '  <meta charset="utf-8">\n'
-    '  <title><?php echo "PERFORMANCE TEST LANDING"; ?></title>\n'
-    '</head>\n'
-    '<body>\n'
-    '  <h1><?php echo "PERFORMANCE TEST LANDING"; ?></h1>\n'
-    '  <p><?php echo "Hello, World!"; ?></p>\n'
-    '</body>\n'
-    '</html>\n'
-)
-
 
 def parse_args():
-    parser = argparse.ArgumentParser(
-        description='Create campaign and flow fixtures for the process performance scenario.'
-    )
-    parser.add_argument(
-        '--action-type',
-        choices=('redirect', 'render'),
-        required=True,
-        help='Flow action type to create for the seeded campaign.',
-    )
+    parser = argparse.ArgumentParser(description='Seed historical tracker data for an existing process campaign.')
+    parser.add_argument('--campaign-id', type=int, required=True, help='Existing campaign id to seed history for.')
     parser.add_argument('--clicks', type=int, default=100_000, help='How many clicks to create.')
     parser.add_argument('--lead-ratio', type=float, default=0.30, help='Fraction of clicks that also get a lead.')
     parser.add_argument(
@@ -54,46 +27,6 @@ def parse_args():
     return parser.parse_args()
 
 
-def create_flow(cursor, campaign_id, action_type):
-    redirect_url = PERF_REDIRECT_URL if action_type == 'redirect' else None
-    payload = {
-        'name': f'{PERF_FLOW_PREFIX} {datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")}',
-        'campaign_id': campaign_id,
-        'rule': None,
-        'order_value': 1,
-        'action_type': action_type,
-        'redirect_url': redirect_url,
-        'is_enabled': True,
-        'is_deleted': False,
-        'created_at': int(datetime.now(timezone.utc).timestamp()),
-    }
-    cursor.execute(
-        '''
-        INSERT INTO flow (
-            name, campaign_id, rule, order_value, action_type, redirect_url, is_enabled, is_deleted, created_at
-        )
-        VALUES (
-            %(name)s, %(campaign_id)s, %(rule)s, %(order_value)s, %(action_type)s, %(redirect_url)s,
-            %(is_enabled)s, %(is_deleted)s, %(created_at)s
-        )
-        ''',
-        payload,
-    )
-    return cursor.lastrowid, payload['name']
-
-
-def create_landing(flow_id):
-    base_path = os.environ.get('LANDING_PAGES_BASE_PATH')
-    if not base_path:
-        raise RuntimeError('LANDING_PAGES_BASE_PATH must be set for render flow seeding.')
-
-    landing_dir = Path(base_path) / str(flow_id)
-    landing_dir.mkdir(parents=True, exist_ok=True)
-    index_path = landing_dir / 'index.php'
-    index_path.write_text(PERF_LANDING_HTML, encoding='utf-8')
-    return str(index_path)
-
-
 def main():
     args = parse_args()
     validate_ratio('lead_ratio', args.lead_ratio)
@@ -103,13 +36,7 @@ def main():
     connection = get_connection()
     try:
         with connection.cursor() as cursor:
-            ensure_empty_campaigns_table(cursor)
-            campaign = create_campaign(cursor)
-            flow_id, flow_name = create_flow(cursor, campaign['id'], args.action_type)
-            landing_index_path = None
-            if args.action_type == 'render':
-                landing_index_path = create_landing(flow_id)
-        connection.commit()
+            campaign = get_campaign(cursor, args.campaign_id)
 
         seed_tracker_tables(
             connection=connection,
@@ -122,23 +49,10 @@ def main():
             seed=args.seed,
             progress_callback=print_progress,
         )
-    except Exception:
-        connection.rollback()
-        raise
     finally:
         connection.close()
 
-    pprint(
-        {
-            'campaign_id': campaign['id'],
-            'campaign_name': campaign['name'],
-            'flow_id': flow_id,
-            'flow_name': flow_name,
-            'action_type': args.action_type,
-            'redirect_url': PERF_REDIRECT_URL if args.action_type == 'redirect' else None,
-            'landing_index_path': landing_index_path,
-        }
-    )
+    pprint({'campaign_id': campaign['id'], 'campaign_name': campaign['name']})
     return 0
 
 

--- a/apps/api/perf/track_and_reports_seed.py
+++ b/apps/api/perf/track_and_reports_seed.py
@@ -4,9 +4,8 @@ import argparse
 from pprint import pprint
 
 from perf_seed_common import (
-    create_campaign,
-    ensure_empty_campaigns_table,
     ensure_safe_db_target,
+    get_campaign,
     get_connection,
     print_progress,
     seed_tracker_tables,
@@ -15,7 +14,8 @@ from perf_seed_common import (
 
 
 def parse_args():
-    parser = argparse.ArgumentParser(description='Seed tracker data for performance testing.')
+    parser = argparse.ArgumentParser(description='Seed historical tracker data for an existing campaign.')
+    parser.add_argument('--campaign-id', type=int, required=True, help='Existing campaign id to seed history for.')
     parser.add_argument('--clicks', type=int, default=100_000, help='How many clicks to create.')
     parser.add_argument('--lead-ratio', type=float, default=0.30, help='Fraction of clicks that also get a lead.')
     parser.add_argument(
@@ -36,9 +36,7 @@ def main():
     connection = get_connection()
     try:
         with connection.cursor() as cursor:
-            ensure_empty_campaigns_table(cursor)
-            campaign = create_campaign(cursor)
-        connection.commit()
+            campaign = get_campaign(cursor, args.campaign_id)
 
         seed_tracker_tables(
             connection=connection,

--- a/infra/installer/install.sh
+++ b/infra/installer/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-BANGI_RELEASE_TAG="0.0.1a56"
+BANGI_RELEASE_TAG="0.0.1a57"
 BANGI_GITHUB_OWNER="devalentino"
 BANGI_GITHUB_REPO="bangi"
 BANGI_RAW_BASE_URL="https://raw.githubusercontent.com/${BANGI_GITHUB_OWNER}/${BANGI_GITHUB_REPO}/${BANGI_RELEASE_TAG}"

--- a/infra/installer/templates/compose.prod.yml
+++ b/infra/installer/templates/compose.prod.yml
@@ -1,6 +1,6 @@
 services:
   web:
-    image: ghcr.io/devalentino/bangi-web:0.0.1a56
+    image: ghcr.io/devalentino/bangi-web:0.0.1a57
     restart: always
     env_file:
       - /opt/bangi/shared/env/.env
@@ -10,7 +10,7 @@ services:
       - bangi
 
   api:
-    image: ghcr.io/devalentino/bangi-api:0.0.1a56
+    image: ghcr.io/devalentino/bangi-api:0.0.1a57
     restart: always
     env_file:
       - /opt/bangi/shared/env/.env


### PR DESCRIPTION
## Summary
- Changes performance seed scripts to seed historical tracker rows for an existing campaign instead of creating campaign, flow, or landing fixtures.
- Adds campaign lookup by `--campaign-id` before seeding tracker history.
- Updates the perf runbook to show explicit DB env variables and `--campaign-id` usage.

## Scope
- Included:
  - `track_and_reports_seed.py` requires `--campaign-id` and seeds history for that campaign.
  - `process_and_reports_seed.py` requires `--campaign-id` and no longer creates flow or landing fixtures.
  - Shared perf seed helpers now load existing campaign metadata for seeded tracker rows.
  - README historical data instructions now match manual campaign/domain setup.
- Not included:
  - Automated test coverage.
  - Dashboard/API automation for campaign, flow, or domain setup.
  - Changes to k6 workload execution behavior.

## Risks
- Medium: existing local workflows that relied on seed scripts creating campaigns/flows must now create the campaign manually first.
- Low: seeded tracker rows still use the same shared insertion logic once the campaign is loaded.

## Links
- Jira: https://bangitech.atlassian.net/browse/KAN-74
- Spec: TBD
