### PR TITLE
KAN-76: feat: improve domains list navigation

### DIFF
--- a/apps/web/src/config.js
+++ b/apps/web/src/config.js
@@ -4,7 +4,7 @@ if (typeof window !== "undefined" && window.APP_CONFIG) {
   runtimeConfig = window.APP_CONFIG;
 }
 
-var backendApiBaseUrl = "/api/v2";
+var backendApiBaseUrl = "https://dashboard.home-and-outdoor.shop/api/v2";
 var debugPersistentAuth = runtimeConfig.DEBUG_PERSIST_AUTH === true
   || runtimeConfig.DEBUG_PERSIST_AUTH === "true";
 

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -101,6 +101,7 @@
   "domains.newManaged": "New Managed Domain",
   "domains.noCampaign": "No campaign",
   "domains.notFound": "No domains found.",
+  "domains.openTarget": "Open live domain",
   "domains.purpose": "Purpose",
   "domains.set": "Set",
   "domains.state": "State",

--- a/apps/web/src/i18n/locales/uk.json
+++ b/apps/web/src/i18n/locales/uk.json
@@ -101,6 +101,7 @@
   "domains.newManaged": "Новий керований домен",
   "domains.noCampaign": "Без кампанії",
   "domains.notFound": "Домени не знайдено.",
+  "domains.openTarget": "Відкрити живий домен",
   "domains.purpose": "Призначення",
   "domains.set": "Встановлено",
   "domains.state": "Стан",

--- a/apps/web/src/views/domains.js
+++ b/apps/web/src/views/domains.js
@@ -66,11 +66,46 @@ class DomainsView {
   }
 
   _campaignBadge(domain) {
-    if (domain.campaignName) {
-      return domain.campaignName;
+    if (domain.campaignId && domain.campaignName) {
+      return m(
+        "a",
+        { href: `#!/core/campaigns/${domain.campaignId}` },
+        domain.campaignName,
+      );
     }
 
     return m("span.text-muted", "-");
+  }
+
+  _targetUrl(hostname) {
+    if (/^[a-z][a-z0-9+.-]*:\/\//i.test(hostname)) {
+      return hostname;
+    }
+
+    return `https://${hostname}`;
+  }
+
+  _hostnameCell(domain) {
+    let openTargetLabel = i18n.t("domains.openTarget");
+
+    return m(".d-flex.align-items-center.gap-2", [
+      m(
+        "a",
+        { href: `#!/domains/${domain.id}` },
+        domain.hostname,
+      ),
+      m(
+        "a.btn.btn-link.btn-sm.p-0",
+        {
+          href: this._targetUrl(domain.hostname),
+          target: "_blank",
+          rel: "noopener noreferrer",
+          title: openTargetLabel,
+          "aria-label": openTargetLabel,
+        },
+        m("i", { class: "fa fa-external-link-alt" }),
+      ),
+    ]);
   }
 
   view() {
@@ -127,11 +162,7 @@ class DomainsView {
                                   m("td", domain.id),
                                   m(
                                     "td",
-                                    m(
-                                      "a",
-                                      { href: `#!/domains/${domain.id}` },
-                                      domain.hostname,
-                                    ),
+                                    this._hostnameCell(domain),
                                   ),
                                   m("td", this._purposeBadge(domain)),
                                   m("td", this._campaignBadge(domain)),

--- a/infra/installer/install.sh
+++ b/infra/installer/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-BANGI_RELEASE_TAG="0.0.1a58"
+BANGI_RELEASE_TAG="0.0.1a59"
 BANGI_GITHUB_OWNER="devalentino"
 BANGI_GITHUB_REPO="bangi"
 BANGI_RAW_BASE_URL="https://raw.githubusercontent.com/${BANGI_GITHUB_OWNER}/${BANGI_GITHUB_REPO}/${BANGI_RELEASE_TAG}"

--- a/infra/installer/templates/compose.prod.yml
+++ b/infra/installer/templates/compose.prod.yml
@@ -1,6 +1,6 @@
 services:
   web:
-    image: ghcr.io/devalentino/bangi-web:0.0.1a58
+    image: ghcr.io/devalentino/bangi-web:0.0.1a59
     restart: always
     env_file:
       - /opt/bangi/shared/env/.env
@@ -10,7 +10,7 @@ services:
       - bangi
 
   api:
-    image: ghcr.io/devalentino/bangi-api:0.0.1a58
+    image: ghcr.io/devalentino/bangi-api:0.0.1a59
     restart: always
     env_file:
       - /opt/bangi/shared/env/.env


### PR DESCRIPTION
## Summary
- Add an external-open action beside each domain hostname so operators can open the live domain in a new tab.
- Preserve the existing hostname link to the internal domain detail route.
- Render attached campaign names as links to their core campaign detail pages.
- Add English and Ukrainian labels for the external-open action.

## Scope
- Included: domains list hostname action, campaign-name navigation, i18n labels, and the existing branch API base URL change.
- Not included: automated UI tests, backend API changes, or changes to domains detail pages.

## Risks
- Low UI risk: the change is limited to domains-list link rendering. Manual verification should confirm internal hostname navigation, external target opening, and campaign navigation.
- Config risk: this branch includes a committed web API base URL change from `/api/v2` to `https://dashboard.home-and-outdoor.shop/api/v2`.

## Links
- Jira: https://bangitech.atlassian.net/browse/KAN-76, https://bangitech.atlassian.net/browse/KAN-78
- Spec: TBD
