### PR TITLE
KAN-80: fix: dashboard campaign filters use selector endpoint

### DIFF
--- a/apps/web/src/models/discard_report.js
+++ b/apps/web/src/models/discard_report.js
@@ -40,11 +40,11 @@ class DiscardReportModel {
     return api
       .request({
         method: "GET",
-        url: `${config.backendApiBaseUrl}/core/campaigns`,
+        url: `${config.backendApiBaseUrl}/core/filters/campaigns`,
       })
       .then(
         function (payload) {
-          this.campaigns = payload.content;
+          this.campaigns = payload;
           this.campaignError = null;
         }.bind(this),
       )

--- a/apps/web/src/models/domain.js
+++ b/apps/web/src/models/domain.js
@@ -44,18 +44,12 @@ class DomainModel {
   fetchCampaigns() {
     this.campaignError = null;
 
-    api.request({
+    return api.request({
       method: "GET",
-      url: `${config.backendApiBaseUrl}/core/campaigns`,
-      params: {
-        page: 1,
-        pageSize: 1000,
-        sortBy: "id",
-        sortOrder: "asc",
-      },
+      url: `${config.backendApiBaseUrl}/core/filters/campaigns`,
     })
       .then(function (payload) {
-        this.campaigns = payload.content;
+        this.campaigns = payload;
       }.bind(this))
       .catch(function () {
         this.campaigns = [];

--- a/apps/web/src/models/expenses_report.js
+++ b/apps/web/src/models/expenses_report.js
@@ -83,10 +83,10 @@ class ExpensesReportModel {
     return api
       .request({
         method: "GET",
-        url: `${config.backendApiBaseUrl}/core/campaigns`,
+        url: `${config.backendApiBaseUrl}/core/filters/campaigns`,
       })
       .then(function (payload) {
-        this.campaigns = payload.content;
+        this.campaigns = payload;
         this.campaignError = null;
       }.bind(this))
       .catch(function () {

--- a/apps/web/src/models/reports_leads.js
+++ b/apps/web/src/models/reports_leads.js
@@ -20,10 +20,10 @@ class ReportsLeadsModel {
 
     return api.request({
       method: "GET",
-      url: `${config.backendApiBaseUrl}/core/campaigns`,
+      url: `${config.backendApiBaseUrl}/core/filters/campaigns`,
     })
       .then(function (payload) {
-        this.campaigns = payload.content || [];
+        this.campaigns = payload || [];
         this.isLoadingCampaigns = false;
       }.bind(this))
       .catch(function () {

--- a/apps/web/src/models/statistics.js
+++ b/apps/web/src/models/statistics.js
@@ -45,10 +45,10 @@ class StatisticsModel {
     return api
       .request({
         method: "GET",
-        url: `${config.backendApiBaseUrl}/core/campaigns`,
+        url: `${config.backendApiBaseUrl}/core/filters/campaigns`,
       })
       .then(function (payload) {
-        this.campaigns = payload.content;
+        this.campaigns = payload;
         this.campaignError = null;
       }.bind(this))
       .catch(function () {

--- a/infra/installer/install.sh
+++ b/infra/installer/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-BANGI_RELEASE_TAG="0.0.1a60"
+BANGI_RELEASE_TAG="0.0.1a61"
 BANGI_GITHUB_OWNER="devalentino"
 BANGI_GITHUB_REPO="bangi"
 BANGI_RAW_BASE_URL="https://raw.githubusercontent.com/${BANGI_GITHUB_OWNER}/${BANGI_GITHUB_REPO}/${BANGI_RELEASE_TAG}"

--- a/infra/installer/templates/compose.prod.yml
+++ b/infra/installer/templates/compose.prod.yml
@@ -1,6 +1,6 @@
 services:
   web:
-    image: ghcr.io/devalentino/bangi-web:0.0.1a60
+    image: ghcr.io/devalentino/bangi-web:0.0.1a61
     restart: always
     env_file:
       - /opt/bangi/shared/env/.env
@@ -10,7 +10,7 @@ services:
       - bangi
 
   api:
-    image: ghcr.io/devalentino/bangi-api:0.0.1a60
+    image: ghcr.io/devalentino/bangi-api:0.0.1a61
     restart: always
     env_file:
       - /opt/bangi/shared/env/.env


### PR DESCRIPTION
## Summary
- Updated report and domain campaign selector loaders to call `/core/filters/campaigns`.
- Adjusted selector loaders to consume the filter endpoint's direct array payload instead of `/core/campaigns` paginated `{ content, pagination }`.
- Kept campaign management/list model calls on `/core/campaigns`.

## Scope
- Included: Leads report, statistics report, discard report, expenses report, and domain campaign selector model loaders.
- Not included: Campaign management list/detail screens, backend endpoint changes, or new test/build workflow changes.

## Risks
- Low. The change is limited to selector data sources, but selectors now rely on the filter endpoint returning the expected `id`/`name` array.

## Links
- Jira: https://bangitech.atlassian.net/browse/KAN-80
- Spec: TBD
