### PR TITLE
KAN-82: migration: add tracker performance indexes

### DIFF
--- a/apps/api/Makefile
+++ b/apps/api/Makefile
@@ -38,4 +38,4 @@ migrate:
 
 generate-migration:
 	echo "=== Generating Migration ==="
-	python scripts/generate_migration.py --database "mysql://$(MARIADB_USER):$(MARIADB_PASSWORD)@$(MARIADB_HOST):$(MARIADB_PORT)/$(MARIADB_DATABASE)" --directory migrations $(name)
+	pw_migrate create  --auto  --auto-source src --directory migrations --database "mysql://$(MARIADB_USER):$(MARIADB_PASSWORD)@$(MARIADB_HOST):$(MARIADB_PORT)/$(MARIADB_DATABASE)" $(name)

--- a/apps/api/Makefile
+++ b/apps/api/Makefile
@@ -38,4 +38,4 @@ migrate:
 
 generate-migration:
 	echo "=== Generating Migration ==="
-	pw_migrate create  --auto  --auto-source src --directory migrations --database "mysql://$(MARIADB_USER):$(MARIADB_PASSWORD)@$(MARIADB_HOST):$(MARIADB_PORT)/$(MARIADB_DATABASE)" $(name)
+	python scripts/generate_migration.py --database "mysql://$(MARIADB_USER):$(MARIADB_PASSWORD)@$(MARIADB_HOST):$(MARIADB_PORT)/$(MARIADB_DATABASE)" --directory migrations $(name)

--- a/apps/api/migrations/015_track_click_track_postback_indexes_improvements.py
+++ b/apps/api/migrations/015_track_click_track_postback_indexes_improvements.py
@@ -1,0 +1,24 @@
+"""Peewee migrations -- 015_track_click_track_postback_indexes_improvements.py."""
+
+from contextlib import suppress
+
+import peewee as pw
+from peewee_migrate import Migrator
+
+
+with suppress(ImportError):
+    import playhouse.postgres_ext as pw_pext
+
+
+def migrate(migrator: Migrator, database: pw.Database, *, fake=False):
+    """Write your migrations here."""
+
+    migrator.add_index('track_postback', 'click_id', 'id', unique=False)
+    migrator.add_index('track_click', 'campaign_id', 'created_at', 'click_id', unique=False)
+
+
+def rollback(migrator: Migrator, database: pw.Database, *, fake=False):
+    """Write your rollback migrations here."""
+
+    migrator.drop_index('track_click', 'campaign_id', 'created_at', 'click_id')
+    migrator.drop_index('track_postback', 'click_id', 'id')

--- a/apps/api/src/tracker/entities.py
+++ b/apps/api/src/tracker/entities.py
@@ -11,7 +11,10 @@ class TrackClick(Entity):
 
     class Meta:
         table_settings = ('ENGINE=Aria', 'TRANSACTIONAL=0')
-        indexes = ((('click_id',), False),)
+        indexes = (
+            (('click_id',), False),
+            (('campaign_id', 'created_at', 'click_id'), False),
+        )
 
 
 class TrackPostback(Entity):
@@ -23,6 +26,7 @@ class TrackPostback(Entity):
 
     class Meta:
         table_settings = ('ENGINE=Aria', 'TRANSACTIONAL=0')
+        indexes = ((('click_id', 'id'), False),)
 
 
 class TrackLead(Entity):

--- a/infra/installer/install.sh
+++ b/infra/installer/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-BANGI_RELEASE_TAG="0.0.1a61"
+BANGI_RELEASE_TAG="0.0.1a62"
 BANGI_GITHUB_OWNER="devalentino"
 BANGI_GITHUB_REPO="bangi"
 BANGI_RAW_BASE_URL="https://raw.githubusercontent.com/${BANGI_GITHUB_OWNER}/${BANGI_GITHUB_REPO}/${BANGI_RELEASE_TAG}"

--- a/infra/installer/templates/compose.prod.yml
+++ b/infra/installer/templates/compose.prod.yml
@@ -1,6 +1,6 @@
 services:
   web:
-    image: ghcr.io/devalentino/bangi-web:0.0.1a61
+    image: ghcr.io/devalentino/bangi-web:0.0.1a62
     restart: always
     env_file:
       - /opt/bangi/shared/env/.env
@@ -10,7 +10,7 @@ services:
       - bangi
 
   api:
-    image: ghcr.io/devalentino/bangi-api:0.0.1a61
+    image: ghcr.io/devalentino/bangi-api:0.0.1a62
     restart: always
     env_file:
       - /opt/bangi/shared/env/.env


### PR DESCRIPTION
## Summary
- Adds migration 015 to create performance indexes for track_postback latest-postback lookups and track_click campaign/date report queries.
- Updates tracker entity metadata so the model definitions reflect the new compound indexes.

## Scope
- Included: API database migration for track_postback(click_id, id) and track_click(campaign_id, created_at, click_id); tracker entity index metadata.
- Not included: migration-history squashing or migration-generation tooling changes; those are tracked separately in KAN-83.

## Risks
- Low schema risk: this adds non-unique indexes only. Migration time depends on track_click and track_postback table size.

## Links
- Jira: https://bangitech.atlassian.net/browse/KAN-82
- Spec: TBD
